### PR TITLE
Use MyProc->pgprocno instead of pg_backend_pid()

### DIFF
--- a/ogawayama_fdw/ogawayama_fdw.cpp
+++ b/ogawayama_fdw/ogawayama_fdw.cpp
@@ -21,6 +21,7 @@ extern "C" {
 #endif
 
 #include "postgres.h"
+#include "storage/proc.h"
 
 #include "ogawayama_fdw.h"
 
@@ -539,7 +540,7 @@ init_fdw_info( FunctionCallInfo fcinfo )
 {
 	fdw_info_.connected = false;
 	fdw_info_.xact_level = 0;
-	fdw_info_.pid = pg_backend_pid( fcinfo );
+	fdw_info_.pid = MyProc->pgprocno;
 	elog( DEBUG1, "PostgreSQL worker process ID: (%d)", fdw_info_.pid );
 	ErrorCode error = make_stub( stub_ );
 	if ( error != ERROR_CODE::OK )


### PR DESCRIPTION
stub_->get_connection()のパラメータにはMyProc->pgprocno（0からTotalProcs-1の連番）を使うべき。getpid()の戻り値となっているMyProcPidは不適切。
（PostgreSQLの該当部分）

--- MyProc->pgprocno ---
        for (i = 0; i < TotalProcs; i++)
        {
                /* Common initialization for all PGPROCs, regardless of type. */
...
                procs[i].pgprocno = i;


 --- MyProcPid ---
pg_backend_pid()は、SELECT pg_backend_pid(); を想定していると思われる。

Datum
pg_backend_pid(PG_FUNCTION_ARGS) 
{
        PG_RETURN_INT32(MyProcPid);
}

void
InitPostmasterChild(void)
{
...
        MyProcPid = getpid();           /* reset MyProcPid */