### PR TITLE
Fix: ERROR invalid memory alloc request size

### DIFF
--- a/ogawayama_fdw/ogawayama_fdw.cpp
+++ b/ogawayama_fdw/ogawayama_fdw.cpp
@@ -925,16 +925,21 @@ make_tuple_from_result_set(ResultSetPtr result_set, OgawayamaFdwState* fdw_state
 					}
 					else
 					{
-						HeapTuple heap_tuple = SearchSysCache1(
+						HeapTuple 	heap_tuple;
+						regproc 	typinput;
+						int 		typemod;
+
+						heap_tuple = SearchSysCache1(
 							TYPEOID, ObjectIdGetDatum(fdw_state->column_types[i]));
 						if (!HeapTupleIsValid(heap_tuple))
 						{
-							elog(ERROR, "cache lookup failed for type %u", 
-								fdw_state->column_types[i]);
+							elog(ERROR, "cache lookup failed for type %u",
+								 fdw_state->column_types[i]);
 						}
-						regproc typinput = ((Form_pg_type) GETSTRUCT(heap_tuple))->typinput;
+						typinput = ((Form_pg_type)GETSTRUCT(heap_tuple))->typinput;
+						typemod = ((Form_pg_type)GETSTRUCT(heap_tuple))->typtypmod;
 						ReleaseSysCache(heap_tuple);
-						tuple->tts_values[i] = OidFunctionCall1(typinput, dat);
+						tuple->tts_values[i] = OidFunctionCall3(typinput, dat, ObjectIdGetDatum(InvalidOid), Int32GetDatum(typemod));
 						tuple->tts_isnull[i] = false;
 					}
 				}


### PR DESCRIPTION
掲題の件、修正しました。

### 原因

ogawayama_fdw/ogawayama_fdw.cpp
make_tuple_from_result_set() 937行目

OidFunctionCall1が使われていることが原因。


```
tuple->tts_values[i] = OidFunctionCall1(typinput, dat);
```

pallocで、atttypmodの値が設定され、2017666240の1GBを超えるメモリを確保しようとする。

```
bpchar_input (s=0x7f1eb1c2e909 "ABC", ' ' <repeats 17 times>, len=20,
    atttypmod=2017666240) at varchar.c:134
134             if (atttypmod < (int32) VARHDRSZ)
(gdb)
140                     maxlen = atttypmod - VARHDRSZ;
(gdb)
141                     charlen = pg_mbstrlen_with_len(s, len);
(gdb)

（略）

Breakpoint 4, palloc (size=2017666240) at mcxt.c:928
928             MemoryContext context = CurrentMemoryContext;
(gdb) s
933             if (!AllocSizeIsValid(size))
```

### 修正

OidFunctionCall3を使う。

```
tuple->tts_values[i] = OidFunctionCall3(typinput, dat, ObjectIdGetDatum(InvalidOid), Int32GetDatum(typemod));
```

atttypmod=-1が設定され、pallocで正しいメモリサイズ24が確保される。

```
FunctionCall3Coll (flinfo=0x7ffcffc1c420, collation=0,
    arg1=139814866057257, arg2=0, arg3=18446744073709551615)
    at fmgr.c:1174
1174    {
(gdb)
1175            LOCAL_FCINFO(fcinfo, 3);
(gdb)
1178            InitFunctionCallInfoData(*fcinfo, flinfo, 3, collation, NULL, NULL);
(gdb)
1180            fcinfo->args[0].value = arg1;
(gdb)
1181            fcinfo->args[0].isnull = false;
(gdb)
1182            fcinfo->args[1].value = arg2;
(gdb)
1183            fcinfo->args[1].isnull = false;
(gdb)
1184            fcinfo->args[2].value = arg3;
(gdb)
1185            fcinfo->args[2].isnull = false;
(gdb)
1187            result = FunctionCallInvoke(fcinfo);
(gdb)
bpcharin (fcinfo=0x7ffcffc1c390) at varchar.c:197
197             char       *s = PG_GETARG_CSTRING(0);
(gdb)
202             int32           atttypmod = PG_GETARG_INT32(2);
(gdb)
205             result = bpchar_input(s, strlen(s), atttypmod);
(gdb)
bpchar_input (s=0x7f292f6cf829 "ABC", ' ' <repeats 17 times>, len=20,
    atttypmod=-1) at varchar.c:134
134             if (atttypmod < (int32) VARHDRSZ)
(gdb)
135                     maxlen = len;
(gdb)
178             result = (BpChar *) palloc(maxlen + VARHDRSZ);
(gdb)
palloc (size=24) at mcxt.c:928
928             MemoryContext context = CurrentMemoryContext;
(gdb)
933             if (!AllocSizeIsValid(size))
(gdb)
936             context->isReset = false;
(gdb)
938             ret = context->methods->alloc(context, size);
(gdb)
```
