### PR TITLE
Modify CI workflows for running on Docker

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -5,8 +5,16 @@ on: [push, pull_request]
 jobs:
   Build:
     name: Build with PosgreSQL ${{ matrix.postgresql }}
-    runs-on: [self-hosted, oltp]
+    runs-on: [self-hosted, docker]
     timeout-minutes: 30
+    container:
+      image:  ghcr.io/project-tsurugi/oltp-sandbox:latest
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GHCR_PAT }}
+    defaults:
+      run:
+        shell: bash
     env:
       BUILD_TYPE: ''
     strategy:
@@ -14,11 +22,6 @@ jobs:
         postgresql: [11.1, 12.3]
 
     steps:
-      - id: Begin
-        name: Begin
-        run: |
-          echo "Begin ${GITHUB_WORKFLOW}/${GITHUB_JOB} hostname:$(hostname)"
-
       - id: Setup_PostgreSQL
         name: Setup_PostgreSQL
         run: |
@@ -36,7 +39,7 @@ jobs:
         with:
           path: postgresql-${{ matrix.postgresql }}/contrib/frontend
           submodules: recursive
-          ssh-key: ${{ secrets.SSH_KEY }}
+          token: ${{ secrets.GHA_PAT }}
 
       - id: CMake_Build_manager
         name: CMake_Build_manager


### PR DESCRIPTION
CIビルドをDocker上で実行するようGitHub Actionsのworkflowスクリプトを変更するPull Requestです。

GitHub Actionsではこれまでprivate Docker registoryを使ったビルドに対応していなかったので、
project-tsurugiがGitHub Actionsに移行したタイミングでやむなくDockerの使用を停止していましたが、
最近ようやくGitHub Container Registoryというprivate registoryに対応したため、
project-tsurugi全体でDockerベースでのCIに戻します。

その他、workflowスクリプトに細かい改善（不要なstepの削除、セキュリティ改善）などを行っています。
問題なければマージお願いします。
