### PR TITLE
Fixreadme

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@
 
 ## Regression tests
 
-Notes: In the current version, the regression test fails due to Issues #63.
+Notes: In the current version, the regression test fails due to [Issues#63](https://github.com/project-tsurugi/frontend/issues/63).
 
 ### Structure
 


### PR DESCRIPTION
READMEを修正しました。


> - devenv.shの記述を削除する
> - OLTPやmanagerのコンポーネントのREADMEを参照してビルドや設定させるような記述を追記する（frontendのREADMEはfrontendの記述のみにする）

* 他のドキュメントで必要なモジュールの記載があったので、Requirementsに以下を追加

```
+* Access to installed dependent modules:
+  * manager
+  * ogawayama
```

* 上記と合わせるように、componentをmoduleに変更

```
-        See the README of each component.
+        See the README of each module.
```

> - OLTPのデグレードでRegression TESTが通らないので実行しないように中期を追加する

* 以下を追記

```
Notes: In the current version, the regression test fails due to [Issues#63](https://github.com/project-tsurugi/frontend/issues/63).
```