### PR TITLE
Feature/prepard statement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 MODULE_big = ogawayama_fdw
 OBJS = common/init.o common/stub_manager.o \
         ogawayama_fdw/deparse.o ogawayama_fdw/shippable.o ogawayama_fdw/tsurugi_utils.o ogawayama_fdw/ogawayama_fdw.o \
+		ogawayama_fdw/tsurugi_prepare.o \
         alt_planner/alt_planner.o \
 		alt_utility/send_message.o \
         alt_utility/alt_utility.o alt_utility/create_stmt.o alt_utility/drop_stmt.o \
@@ -15,6 +16,7 @@ OBJS = common/init.o common/stub_manager.o \
 		alt_utility/role_managercmds.o alt_utility/table_managercmds.o alt_utility/syscachecmds.o  \
         alt_utility/alter_table/alter_table_executor.o alt_utility/alter_table/alter_table.o \
 		alt_utility/alter_role/alter_role.o \
+		alt_utility/prepare_execute/prepare_execute.o \
         alt_function/alt_function.o \
         $(WIN32RES)
 
@@ -24,7 +26,7 @@ DATA = ogawayama_fdw--0.1.sql
 # REGRESS_BASIC: variable used in frontend
 #REGRESS_BASIC = test_create_table otable_of_constr ch-benchmark-ddl create_table_syntax_type update_delete insert_select
 REGRESS_BASIC = test_preparation create_table insert_select_happy update_delete select_statements user_management \
-                udf_transaction
+                udf_transaction prepare_statment prepare_select_statment
 ifdef REGRESS_EXTRA
 	# REGRESS: variable defined in PostgreSQL
 	REGRESS = $(REGRESS_BASIC) otable_of_constr2

--- a/alt_utility/alt_utility.c
+++ b/alt_utility/alt_utility.c
@@ -43,6 +43,7 @@
 #include "alter_role/alter_role.h"
 #include "grant_revoke_role/grant_revoke_role.h"
 #include "grant_revoke_table/grant_revoke_table.h"
+#include "prepare_execute/prepare_execute.h"
 
 #ifndef PG_MODULE_MAGIC
 PG_MODULE_MAGIC;
@@ -289,6 +290,32 @@ tsurugi_ProcessUtility(PlannedStmt *pstmt,
 			if (!after_grant_revoke_role((GrantRoleStmt*)parsetree))
 			{
 				elog(ERROR, "failed after_grant_revoke_role() function.");
+			}
+			break;
+		}
+
+		case T_PrepareStmt:
+		{
+			standard_ProcessUtility(pstmt, queryString, context, params, queryEnv,
+									dest, completionTag);
+			if (!after_prepare_stmt((PrepareStmt*)parsetree, queryString))
+			{
+				elog(ERROR, "failed after_prepare_stmt() function.");
+			}
+			break;
+		}
+
+		case T_ExecuteStmt:
+		{
+			if (!befor_execute_stmt((ExecuteStmt*)parsetree))
+			{
+				elog(ERROR, "failed befor_execute_stmt() function.");
+			}
+			standard_ProcessUtility(pstmt, queryString, context, params, queryEnv,
+									dest, completionTag);
+			if (!after_execute_stmt((ExecuteStmt*)parsetree))
+			{
+				elog(ERROR, "failed after_execute_stmt() function.");
 			}
 			break;
 		}

--- a/alt_utility/prepare_execute/prepare_execute.cpp
+++ b/alt_utility/prepare_execute/prepare_execute.cpp
@@ -1,0 +1,1880 @@
+/*
+ * Copyright 2023 tsurugi project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *	@file	prepare_execute.cpp
+ *	@brief  Dispatch the prepare command to ogawayama.
+ */
+
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "manager/metadata/metadata_factory.h"
+#include "ogawayama/stub/api.h"
+#include "stub_manager.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "postgres.h"
+#include "catalog/pg_type.h"
+#include "commands/prepare.h"
+#include "lib/stringinfo.h"
+#include "nodes/parsenodes.h"
+#include "parser/parse_type.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#include "prepare_execute.h"
+
+using namespace ogawayama;
+
+PreparedStatementPtr prepared_statement;
+stub::parameters_type parameters{};
+
+std::map<std::string, PreparedStatementPtr> stored_prepare_statment;
+std::map<std::string, std::vector<Oid>> stored_argtypes;
+
+bool deparse_where_clause(Node* expr, const Oid* argtypes, stub::placeholders_type& placeholders, StringInfo buf);
+bool deparse_expr_recurse(Node* expr, const Oid* argtypes, stub::placeholders_type& placeholders, std::string& col_name, StringInfo buf);
+void deparse_execute_where_clause(const Node* expr, const ExecuteStmt* stmts);
+bool deparse_execute_expr_recurse(Node* expr, std::string& col_name, const ExecuteStmt* stmts);
+void deparse_select_query(const SelectStmt* stmt, const Oid* argtypes, stub::placeholders_type& placeholders, StringInfo buf);
+
+void
+get_tsurugi_table_join_expr(JoinExpr* join,
+							std::vector<std::string>& target_tables)
+{
+	switch (nodeTag(join->larg))
+	{
+		case T_RangeVar:
+			{
+				RangeVar* relation = (RangeVar *) join->larg;
+				target_tables.emplace_back(relation->relname);
+			}
+			break;
+		case T_JoinExpr:
+			{
+				get_tsurugi_table_join_expr((JoinExpr *)join->larg, target_tables);
+			}
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "unsupported join larg %d", (int) nodeTag(join->larg));
+			break;
+	}
+
+	if (IsA(join->rarg, RangeVar)) {
+		RangeVar* relation = (RangeVar *) join->rarg;
+		target_tables.emplace_back(relation->relname);
+	}
+}
+
+/**
+ *  @brief Tsurugi OLTP table exist in the target relation.
+ *  @param [in] query
+ *  @return true if Tsurugi OLTP table exists.
+ */
+bool
+is_tsurugi_table(Node* query,
+				 bool show_warning)
+{
+	bool result = false;
+	bool is_tsurugi = false;
+	bool is_not_tsurugi = false;
+	std::vector<std::string> target_tables;
+
+	switch (nodeTag(query))
+	{
+		case T_InsertStmt:
+			{
+				InsertStmt* stmt = (InsertStmt *) query;
+				target_tables.emplace_back(stmt->relation->relname);
+			}
+			break;
+		case T_UpdateStmt:
+			{
+				UpdateStmt* stmt = (UpdateStmt *) query;
+				target_tables.emplace_back(stmt->relation->relname);
+			}
+			break;
+		case T_DeleteStmt:
+			{
+				DeleteStmt* stmt = (DeleteStmt *) query;
+				target_tables.emplace_back(stmt->relation->relname);
+			}
+			break;
+		case T_SelectStmt:
+			{
+				SelectStmt* stmt = (SelectStmt *) query;
+				ListCell* l;
+				foreach(l, stmt->fromClause)
+				{
+					Node* from = (Node *) lfirst(l);
+					if (IsA(from, RangeVar)) {
+						RangeVar* relation = (RangeVar *) from;
+						target_tables.emplace_back(relation->relname);
+					}
+					if (IsA(from, JoinExpr)) {
+						get_tsurugi_table_join_expr((JoinExpr *) from, target_tables);
+					}
+				}
+			}
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "is_tsurugi_table: unrecognized node type: %d",
+				 (int) nodeTag(query));
+			return result;
+	}
+
+	auto tables = manager::metadata::get_tables_ptr("Tsurugi");
+	for(std::size_t i = 0; i < target_tables.size(); i++) {
+		if (tables->exists(target_tables[i])) {
+			is_tsurugi = true;
+		} else {
+			is_not_tsurugi = true;
+		}
+	}
+
+	if (is_tsurugi) {
+		if (is_not_tsurugi) {
+			if (show_warning) {
+				elog(WARNING,
+					"If Tsurugi and non-Tsurugi tables are mixed, do not PREPARE to Tsurugi");
+			}
+		} else {
+			result = true;
+		}
+	}
+
+	return result;
+}
+
+/**
+ *  @brief Transform list of TypeNames to array of type OIDs.
+ *  @param [in] list of TypeNames
+ *  @param [in] query String
+ *  @return pointer to array of type OIDs.
+ */
+Oid*
+transform_typenames_to_oids(const List* argtypes,
+							std::vector<Oid>& argtypes_v,
+							const char* queryString)
+{
+	Oid* argoids = nullptr;
+	int nargs;
+	int i;
+
+	nargs = list_length(argtypes);
+	if (nargs)
+	{
+		ParseState* pstate;
+		ListCell* l;
+
+		/*
+		 * typenameTypeId wants a ParseState to carry the source query string.
+		 * Is it worth refactoring its API to avoid this?
+		 */
+		pstate = make_parsestate(nullptr);
+		pstate->p_sourcetext = queryString;
+
+		argoids = (Oid *) palloc(nargs * sizeof(Oid));
+		i = 0;
+
+		foreach(l, argtypes)
+		{
+			TypeName* tn = (TypeName *)lfirst(l);
+			Oid toid = typenameTypeId(pstate, tn);
+
+			argoids[i++] = toid;
+			argtypes_v.push_back(toid);
+		}
+	}
+
+	return argoids;
+}
+
+void
+deparse_query_columns(const List* cols,
+					   std::vector<std::string>& col_names,
+					   StringInfo buf)
+{
+	bool first = true;
+	ListCell* lc;
+
+	appendStringInfoChar(buf, '(');
+	foreach(lc, cols)
+	{
+		ResTarget* col = lfirst_node(ResTarget, lc);
+		if (!first)
+			appendStringInfoString(buf, ", ");
+		first = false;
+		appendStringInfo(buf, "%s", col->name);
+		col_names.push_back(col->name);
+	}
+	appendStringInfoChar(buf, ')');
+}
+
+bool
+deparse_value_paramref(const ParamRef* param,
+					   const Oid* argtypes,
+					   std::string col_name,
+					   stub::placeholders_type& placeholders,
+					   StringInfo buf)
+{
+	bool result{true};
+	int num = param->number;
+	col_name += "_" + std::to_string(num);
+	appendStringInfo(buf, ":%s", col_name.c_str());
+
+	switch (argtypes[num-1])
+	{
+		case INT2OID:
+			placeholders.emplace_back(col_name,
+							stub::Metadata::ColumnType::Type::INT16);
+			break;
+		case INT4OID:
+			placeholders.emplace_back(col_name,
+							stub::Metadata::ColumnType::Type::INT32);
+			break;
+		case INT8OID:
+			placeholders.emplace_back(col_name,
+							stub::Metadata::ColumnType::Type::INT64);
+			break;
+		case FLOAT4OID:
+			placeholders.emplace_back(col_name,
+							stub::Metadata::ColumnType::Type::FLOAT32);
+			break;
+		case FLOAT8OID:
+			placeholders.emplace_back(col_name,
+							stub::Metadata::ColumnType::Type::FLOAT64);
+			break;
+		case BPCHAROID:
+		case VARCHAROID:
+		case TEXTOID:
+			placeholders.emplace_back(col_name,
+							stub::Metadata::ColumnType::Type::TEXT);
+			break;
+		case DATEOID:
+			placeholders.emplace_back(col_name,
+							stub::Metadata::ColumnType::Type::DATE);
+			break;
+		case TIMEOID:
+			placeholders.emplace_back(col_name,
+							stub::Metadata::ColumnType::Type::TIME);
+			break;
+		case TIMESTAMPOID:
+			placeholders.emplace_back(col_name,
+							stub::Metadata::ColumnType::Type::TIMESTAMP);
+			break;
+		case TIMETZOID:
+			placeholders.emplace_back(col_name,
+							stub::Metadata::ColumnType::Type::TIMETZ);
+			break;
+		case TIMESTAMPTZOID:
+			placeholders.emplace_back(col_name,
+							stub::Metadata::ColumnType::Type::TIMESTAMPTZ);
+			break;
+		case NUMERICOID:
+			placeholders.emplace_back(col_name,
+							stub::Metadata::ColumnType::Type::DECIMAL);
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "unrecognized type oid: %d",
+				 (int) argtypes[num-1]);
+			result = false;
+			break;
+	}
+
+	return result;
+}
+
+bool
+deparse_value_ref(const Node* value,
+				  const Oid* argtypes,
+				  const std::vector<std::string>& col_names,
+				  stub::placeholders_type& placeholders,
+				  StringInfo buf)
+{
+	bool result{true};
+
+	switch (nodeTag(value))
+	{
+		case T_ParamRef:
+			{
+				ParamRef* param_ref = (ParamRef *)value;
+				int param_num = param_ref->number;
+				std::string col_name = col_names[param_num-1];
+				deparse_value_paramref((ParamRef *)value, argtypes, col_name, placeholders, buf);
+			}
+			break;
+		case T_A_Const:
+			{
+				A_Const* con = (A_Const *)value;
+				Value* val = &con->val;
+				switch (nodeTag(val))
+				{
+					case T_Integer:
+						appendStringInfo(buf, "%d", intVal(val));
+						break;
+					case T_Float:
+						appendStringInfo(buf, "%f", floatVal(val));
+						break;
+					case T_String:
+						appendStringInfo(buf, "\'%s\'", strVal(val));
+						break;
+					default:
+						/* should not reach here */
+						elog(ERROR, "value_ref: unrecognized a_const value node type: %d",
+							 (int) nodeTag(value));
+						result = false;
+						return result;
+				}
+			}
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "unrecognized value node type: %d",
+				 (int) nodeTag(value));
+			result = false;
+			return result;
+	}
+
+	return result;
+}
+
+bool
+deparse_values_lists(const List* valuesLists,
+					 const Oid* argtypes,
+					 std::vector<std::string>& col_names,
+					 stub::placeholders_type& placeholders,
+					 StringInfo buf)
+{
+	bool result{true};
+	bool first_list = true;
+	ListCell* vtl;
+	foreach(vtl, valuesLists)
+	{
+		List* values = (List *) lfirst(vtl);
+		bool first_col = true;
+		int col_names_pos = 0;
+		ListCell* lc;
+
+		if (first_list)
+			first_list = false;
+		else
+			appendStringInfoString(buf, ", ");
+
+		appendStringInfoChar(buf, '(');
+		foreach(lc, values)
+		{
+			Node* value = (Node *) lfirst(lc);
+
+			if (!first_col)
+				appendStringInfoString(buf, ", ");
+			first_col = false;
+
+			result = deparse_value_ref(value, argtypes, col_names, placeholders, buf);
+			if (result == false) {
+				return result;
+			}
+			if (IsA(value, A_Const)) {
+				col_names.erase(col_names.begin() + col_names_pos);
+			}
+			col_names_pos++;
+		}
+		appendStringInfoChar(buf, ')');
+	}
+
+	return result;
+}
+
+char *
+deparse_column_ref(ColumnRef* cref,
+				   char* alias,
+				   StringInfo buf)
+{
+	char* result;
+
+	/*----------
+	 * The allowed syntaxes are:
+	 *
+	 * A		First try to resolve as unqualified column name;
+	 *			if no luck, try to resolve as unqualified table name (A.*).
+	 * A.B		A is an unqualified table name; B is either a
+	 *			column or function name (trying column name first).
+	 * A.B.C	schema A, table B, col or func name C.
+	 * A.B.C.D	catalog A, schema B, table C, col or func D.
+	 * A.*		A is an unqualified table name; means whole-row value.
+	 * A.B.*	whole-row value of table B in schema A.
+	 * A.B.C.*	whole-row value of table C in schema B in catalog A.
+	 *
+	 * We do not need to cope with bare "*"; that will only be accepted by
+	 * the grammar at the top level of a SELECT list, and transformTargetList
+	 * will take care of it before it ever gets here.  Also, "A.*" etc will
+	 * be expanded by transformTargetList if they appear at SELECT top level,
+	 * so here we are only going to see them as function or operator inputs.
+	 *
+	 * Currently, if a catalog name is given then it must equal the current
+	 * database name; we check it here and then discard it.
+	 *----------
+	 */
+	switch (list_length(cref->fields))
+	{
+		case 1:
+			{
+				Node* field1 = (Node*) linitial(cref->fields);
+				if (IsA(field1, A_Star)) {
+					if (buf != NULL) {
+						appendStringInfoString(buf, "*");
+					}
+				} else if (IsA(field1, String)) {
+					if (buf != NULL) {
+						appendStringInfo(buf, "%s", strVal(field1));
+					}
+					result = strVal(field1);
+					if (alias != NULL) {
+						if (buf != NULL) {
+							appendStringInfo(buf, " AS %s", alias);
+						}
+					}
+				}
+			}
+			break;
+		case 2:
+			{
+				Node* field1 = (Node*) linitial(cref->fields);
+				Node* field2 = (Node*) lsecond(cref->fields);
+				if (IsA(field2, A_Star)) {
+					if (buf != NULL) {
+						appendStringInfo(buf, "%s.*", strVal(field1));
+					}
+				} else if (IsA(field2, String)) {
+					if (buf != NULL) {
+						appendStringInfo(buf, "%s.%s", strVal(field1),
+														strVal(field2));
+					}
+					result = strVal(field2);
+					if (alias != NULL) {
+						if (buf != NULL) {
+							appendStringInfo(buf, " AS %s", alias);
+						}
+					}
+				}
+			}
+			break;
+		case 3:
+			{
+				Node* field3 = (Node*) lthird(cref->fields);
+				Assert(IsA(field3, String));
+				result = strVal(field3);
+				break;
+			}
+		case 4:
+			{
+				Node* field4 = (Node*) lfourth(cref->fields);
+				Assert(IsA(field4, String));
+				result = strVal(field4);
+				break;
+			}
+		default:
+			/* should not reach here */
+			elog(ERROR, "improper qualified name (too many dotted names)");
+			break;
+	}
+
+	return result;
+}
+
+bool
+deparse_a_const(Value* value,
+				StringInfo buf)
+{
+	bool result{true};
+
+	switch (nodeTag(value))
+	{
+		case T_Integer:
+			if (buf != NULL) {
+				appendStringInfo(buf, "%d ", intVal(value));
+			}
+			break;
+		case T_Float:
+			if (buf != NULL) {
+				appendStringInfo(buf, "%f ", floatVal(value));
+			}
+			break;
+		case T_String:
+			if (buf != NULL) {
+				appendStringInfo(buf, "\'%s\' ", strVal(value));
+			}
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "unrecognized a_const node type: %d", (int) nodeTag(value));
+			result = false;
+			break;
+	}
+
+	return result;
+}
+
+bool
+deparse_aexpr_op(A_Expr* a,
+			     const Oid* argtypes,
+			     stub::placeholders_type& placeholders,
+				 StringInfo buf)
+{
+	Node* lexpr = a->lexpr;
+	Node* rexpr = a->rexpr;
+	std::string col_name;
+	bool result{true};
+
+	result = deparse_expr_recurse(lexpr, argtypes, placeholders, col_name, buf);
+	if (result != true) {
+		return result;
+	}
+
+	switch (list_length(a->name))
+	{
+		case 1:
+			appendStringInfo(buf, " %s ", strVal(linitial(a->name)));
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "deparse_aexpr_op: list_length = %d", list_length(a->name));
+			result = false;
+			break;
+	}
+
+	result = deparse_expr_recurse(rexpr, argtypes, placeholders, col_name, buf);
+
+	return result;
+}
+
+bool
+deparse_aexpr_between(A_Expr* a,
+			     const Oid* argtypes,
+			     stub::placeholders_type& placeholders,
+				 StringInfo buf)
+{
+	Node* lexpr = a->lexpr;
+	List* rexpr = (List *) a->rexpr;
+	std::string col_name;
+	bool result{true};
+
+	result = deparse_expr_recurse(lexpr, argtypes, placeholders, col_name, buf);
+	if (result != true) {
+		return result;
+	}
+
+	switch (list_length(a->name))
+	{
+		case 1:
+			appendStringInfo(buf, " %s ", strVal(linitial(a->name)));
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "deparse_aexpr_between: list_length = %d", list_length(a->name));
+			result = false;
+			break;
+	}
+
+	ListCell   *lc;
+	int name_num = 0;
+	const char* sep = "";
+	foreach(lc, rexpr)
+	{
+		Node* expr = (Node *) lfirst(lc);
+		std::string name = col_name + std::to_string(name_num);
+		appendStringInfoString(buf, sep);
+		result = deparse_expr_recurse(expr, argtypes, placeholders, name, buf);
+		if (result != true) {
+			return result;
+		}
+		sep = "AND ";
+	}
+
+	return result;
+}
+
+bool
+deparse_aexpr_like(A_Expr* a,
+			     const Oid* argtypes,
+			     stub::placeholders_type& placeholders,
+				 StringInfo buf)
+{
+	Node* lexpr = a->lexpr;
+	Node* rexpr = a->rexpr;
+	std::string col_name;
+	bool result{true};
+
+	result = deparse_expr_recurse(lexpr, argtypes, placeholders, col_name, buf);
+	if (result != true) {
+		return result;
+	}
+
+	switch (list_length(a->name))
+	{
+		case 1:
+//			appendStringInfo(buf, "%s ", strVal(linitial(a->name)));
+			appendStringInfoString(buf, " LIKE ");
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "deparse_aexpr_op: list_length = %d", list_length(a->name));
+			result = false;
+			break;
+	}
+
+	result = deparse_expr_recurse(rexpr, argtypes, placeholders, col_name, buf);
+	if (result != true) {
+		return result;
+	}
+
+	return result;
+}
+
+bool
+deparse_aexpr_in(A_Expr* a,
+			     const Oid* argtypes,
+			     stub::placeholders_type& placeholders,
+				 StringInfo buf)
+{
+	Node* lexpr = a->lexpr;
+	List* rexpr = (List *) a->rexpr;
+	std::string col_name;
+	bool result{true};
+
+	result = deparse_expr_recurse(lexpr, argtypes, placeholders, col_name, buf);
+	if (result != true) {
+		return result;
+	}
+
+	switch (list_length(a->name))
+	{
+		case 1:
+//			appendStringInfo(buf, "%s ", strVal(linitial(a->name)));
+			appendStringInfoString(buf, " IN ");
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "deparse_aexpr_between: list_length = %d", list_length(a->name));
+			result = false;
+			break;
+	}
+
+	ListCell   *lc;
+	int name_num = 0;
+	const char* sep = "";
+	appendStringInfoString(buf, "(");
+	foreach(lc, rexpr)
+	{
+		Node* expr = (Node *) lfirst(lc);
+		std::string name = col_name + std::to_string(name_num);
+		appendStringInfoString(buf, sep);
+		result = deparse_expr_recurse(expr, argtypes, placeholders, name, buf);
+		if (result != true) {
+			return result;
+		}
+		sep = ", ";
+	}
+	appendStringInfoString(buf, ")");
+
+	return result;
+}
+
+bool
+deparse_bool_expr(BoolExpr* a,
+				  const Oid* argtypes,
+				  stub::placeholders_type& placeholders,
+				  StringInfo buf)
+{
+	const char* opname;
+	ListCell   *lc;
+	bool result{true};
+
+	switch (a->boolop)
+	{
+		case AND_EXPR:
+			opname = "AND";
+			break;
+		case OR_EXPR:
+			opname = "OR";
+			break;
+		case NOT_EXPR:
+			opname = "NOT";
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "deparse_bool_expr: unrecognized boolop: %d", (int) a->boolop);
+			result = false;
+			return result;
+	}
+
+	bool set_opname{false};
+	foreach(lc, a->args)
+	{
+		Node* arg = (Node *) lfirst(lc);
+		result = deparse_where_clause(arg, argtypes, placeholders, buf);
+		if (result != true) {
+			return result;
+		}
+		if (set_opname != true) {
+			appendStringInfo(buf, " %s ", opname);
+			set_opname = true;
+		}
+	}
+
+	return result;
+}
+
+bool
+deparse_expr_recurse(Node* expr,
+					 const Oid* argtypes,
+					 stub::placeholders_type& placeholders,
+					 std::string& col_name,
+					 StringInfo buf)
+{
+	bool result{true};
+
+	switch (nodeTag(expr))
+	{
+		case T_ColumnRef:
+			col_name = deparse_column_ref((ColumnRef*) expr, NULL, buf);
+			break;
+
+		case T_A_Const:
+			{
+				A_Const* con = (A_Const *) expr;
+				Value* val = &con->val;
+				result = deparse_a_const(val, buf);
+				break;
+			}
+
+		case T_ParamRef:
+			{
+				deparse_value_paramref((ParamRef *)expr, argtypes, col_name, placeholders, buf);
+				break;
+			}
+
+		case T_A_Expr:
+			{
+				A_Expr* a = (A_Expr *) expr;
+				switch (a->kind)
+				{
+					case AEXPR_OP:
+						result = deparse_aexpr_op(a, argtypes, placeholders, buf);
+						break;
+					case AEXPR_BETWEEN:
+						result = deparse_aexpr_between(a, argtypes, placeholders, buf);
+						break;
+					case AEXPR_LIKE:
+						result = deparse_aexpr_like(a, argtypes, placeholders, buf);
+						break;
+					case AEXPR_IN:
+						result = deparse_aexpr_in(a, argtypes, placeholders, buf);
+						break;
+					default:
+						/* should not reach here */
+						elog(ERROR, "unrecognized A_Expr kind: %d", a->kind);
+						result = false;
+						break;
+				}
+				break;
+			}
+
+		case T_BoolExpr:
+			result = deparse_bool_expr((BoolExpr*) expr, argtypes, placeholders, buf);
+			break;
+
+		case T_SubLink:
+			{
+				SubLink* sub_link = (SubLink *) expr;
+				appendStringInfoString(buf, "EXISTS (");
+				deparse_select_query((SelectStmt*) sub_link->subselect, argtypes, placeholders, buf);
+				appendStringInfoString(buf, ")");
+			}
+			break;
+
+		case T_FuncCall:
+			{
+				FuncCall* func = (FuncCall *) expr;
+				ListCell* l;
+				foreach(l, func->funcname){
+					Node* name = (Node *) lfirst(l);
+					if (IsA(name, String)) {
+						appendStringInfo(buf, "%s", strVal(name));
+					}
+				}
+				appendStringInfoChar(buf, '(');
+				foreach(l, func->args){
+					Node* args = (Node *) lfirst(l);
+					if (IsA(args, ColumnRef)) {
+						deparse_column_ref((ColumnRef*) args, NULL, buf);
+					}
+				}
+				appendStringInfoChar(buf, ')');
+			}
+			break;
+
+		default:
+			/* should not reach here */
+			elog(ERROR, "unrecognized expr node type: %d", (int) nodeTag(expr));
+			result = false;
+			break;
+	}
+
+	return result;
+}
+
+bool
+deparse_where_clause(Node* expr,
+					 const Oid* argtypes,
+					 stub::placeholders_type& placeholders,
+					 StringInfo buf)
+{
+	bool result{true};
+
+	switch (nodeTag(expr))
+	{
+		case T_A_Expr:
+			{
+				A_Expr* a = (A_Expr *) expr;
+				switch (a->kind)
+				{
+					case AEXPR_OP:
+						result = deparse_aexpr_op(a, argtypes, placeholders, buf);
+						break;
+					case AEXPR_BETWEEN:
+						result = deparse_aexpr_between(a, argtypes, placeholders, buf);
+						break;
+					case AEXPR_LIKE:
+						result = deparse_aexpr_like(a, argtypes, placeholders, buf);
+						break;
+					case AEXPR_IN:
+						result = deparse_aexpr_in(a, argtypes, placeholders, buf);
+						break;
+					default:
+						/* should not reach here */
+						elog(ERROR, "unrecognized where clause A_Expr kind: %d", a->kind);
+						result = false;
+						break;
+				}
+				break;
+			}
+
+		case T_BoolExpr:
+			result = deparse_bool_expr((BoolExpr*) expr, argtypes, placeholders, buf);
+			break;
+
+		case T_SubLink:
+			{
+				SubLink* sub_link = (SubLink *) expr;
+				appendStringInfoString(buf, "EXISTS (");
+				deparse_select_query((SelectStmt*) sub_link->subselect, argtypes, placeholders, buf);
+				appendStringInfoString(buf, ")");
+			}
+			break;
+
+		default:
+			/* should not reach here */
+			elog(ERROR, "unrecognized where clause expr node type: %d", (int) nodeTag(expr));
+			result = false;
+			break;
+	}
+
+	return result;
+}
+
+void
+deparse_sort_clause(List* sortClause,
+					 StringInfo buf)
+{
+	const char* sep = "";
+	ListCell* l;
+	foreach(l, sortClause)
+	{
+		Node* sort = (Node *) lfirst(l);
+		if (IsA(sort, SortBy)) {
+			SortBy* sortby = (SortBy *) sort;
+			appendStringInfoString(buf, sep);
+			if (IsA(sortby->node, ColumnRef)) {
+				deparse_column_ref((ColumnRef*) sortby->node, NULL, buf);
+			}
+			if (IsA(sortby->node, A_Const)) {
+				A_Const* con = (A_Const *) sortby->node;
+				Value* val = &con->val;
+				deparse_a_const(val, buf);
+			}
+			switch (sortby->sortby_dir)
+			{
+				case SORTBY_DEFAULT:
+					break;
+				case SORTBY_ASC:
+					{
+						appendStringInfoString(buf, " ASC");
+					}
+					break;
+				case SORTBY_DESC:
+					{
+						appendStringInfoString(buf, " DESC");
+					}
+					break;
+				default:
+					/* should not reach here */
+					elog(ERROR, "unrecognized sortby dir: %d",
+						 sortby->sortby_dir);
+					return;
+			}
+			switch (sortby->sortby_nulls)
+			{
+				case SORTBY_NULLS_DEFAULT:
+					break;
+				case SORTBY_NULLS_FIRST:
+					{
+						appendStringInfoString(buf, " NULLS FIRST");
+					}
+					break;
+				case SORTBY_NULLS_LAST:
+					{
+						appendStringInfoString(buf, " NULLS LAST");
+					}
+					break;
+				default:
+					/* should not reach here */
+					elog(ERROR, "unrecognized sortby dir: %d",
+						 sortby->sortby_dir);
+					return;
+			}
+			sep = ", ";
+		}
+	}
+}
+
+void
+deparse_join_expr(JoinExpr* join,
+				  const Oid* argtypes,
+				  stub::placeholders_type& placeholders,
+				  StringInfo buf)
+{
+	switch (nodeTag(join->larg))
+	{
+		case T_RangeVar:
+			{
+				RangeVar* relation = (RangeVar *) join->larg;
+				appendStringInfo(buf, "%s", relation->relname);
+				if (relation->alias != NULL) {
+					appendStringInfo(buf, " %s", relation->alias->aliasname);
+				}
+			}
+			break;
+		case T_JoinExpr:
+			{
+				deparse_join_expr((JoinExpr *)join->larg, argtypes, placeholders, buf);
+			}
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "unsupported join larg %d", (int) nodeTag(join->larg));
+			break;
+	}
+
+	switch (join->jointype)
+	{
+		case JOIN_INNER:
+			if (join->quals != NULL) {
+				appendStringInfoString(buf, " INNER JOIN ");
+			} else {
+				appendStringInfoString(buf, " CROSS JOIN ");
+			}
+			break;
+		case JOIN_LEFT:
+			appendStringInfoString(buf, " LEFT JOIN ");
+			break;
+		case JOIN_RIGHT:
+			appendStringInfoString(buf, " RIGHT JOIN ");
+			break;
+		case JOIN_FULL:
+			appendStringInfoString(buf, " FULL JOIN ");
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "unsupported join type %d", join->jointype);
+			break;
+	}
+
+	if (IsA(join->rarg, RangeVar)) {
+		RangeVar* relation = (RangeVar *) join->rarg;
+		appendStringInfo(buf, "%s", relation->relname);
+		if (relation->alias != NULL) {
+			appendStringInfo(buf, " %s", relation->alias->aliasname);
+		}
+	}
+
+	if (join->usingClause != NULL) {
+		bool first = true;
+		ListCell* lc;
+
+		appendStringInfoString(buf, " USING (");
+		foreach(lc, join->usingClause)
+		{
+			Node* using_clause = (Node *) lfirst(lc);
+			if (IsA(using_clause, String)) {
+				if (!first)
+					appendStringInfoString(buf, ", ");
+				first = false;
+				appendStringInfo(buf, "%s", strVal(using_clause));
+			}
+		}
+		appendStringInfoChar(buf, ')');
+	}
+
+	if (join->quals != NULL) {
+		appendStringInfoString(buf, " ON ");
+		deparse_where_clause(join->quals, argtypes, placeholders, buf);
+	}
+}
+
+void
+deparse_insert_query(const InsertStmt* stmt,
+					 const Oid* argtypes,
+					 stub::placeholders_type& placeholders,
+					 StringInfo buf)
+{
+	std::vector<std::string> col_names;
+
+	appendStringInfo(buf, "INSERT INTO %s ", stmt->relation->relname);
+
+	deparse_query_columns(stmt->cols, col_names, buf);
+
+	appendStringInfoString(buf, " VALUES ");
+
+	SelectStmt* selectStmt = (SelectStmt *)stmt->selectStmt;
+	deparse_values_lists(selectStmt->valuesLists, argtypes, col_names, placeholders, buf);
+}
+
+void
+deparse_update_query(const UpdateStmt* stmt,
+					 const Oid* argtypes,
+					 stub::placeholders_type& placeholders,
+					 StringInfo buf)
+{
+	appendStringInfo(buf, "UPDATE %s ", stmt->relation->relname);
+
+	appendStringInfoString(buf, "SET ");
+
+	bool first = true;
+	ListCell* lc;
+	foreach(lc, stmt->targetList)
+	{
+		ResTarget* col = lfirst_node(ResTarget, lc);
+		if (!first)
+			appendStringInfoString(buf, ", ");
+		first = false;
+		appendStringInfo(buf, "%s = ", col->name);
+		if (IsA(col->val, ParamRef)) {
+			deparse_value_paramref((ParamRef *)col->val, argtypes, col->name, placeholders, buf);
+		}
+		if (IsA(col->val, A_Const)) {
+			A_Const* con = (A_Const *) col->val;
+			Value* val = &con->val;
+			deparse_a_const(val, buf);
+		}
+	}
+
+	if (stmt->whereClause != NULL) {
+		appendStringInfoString(buf, " WHERE ");
+		deparse_where_clause(stmt->whereClause, argtypes, placeholders, buf);
+	}
+}
+
+void
+deparse_delete_query(const DeleteStmt* stmt,
+					 const Oid* argtypes,
+					 stub::placeholders_type& placeholders,
+					 StringInfo buf)
+{
+	appendStringInfo(buf, "DELETE FROM %s ", stmt->relation->relname);
+
+	if (stmt->whereClause != NULL) {
+		appendStringInfoString(buf, " WHERE ");
+		deparse_where_clause(stmt->whereClause, argtypes, placeholders, buf);
+	}
+}
+
+void
+deparse_select_query(const SelectStmt* stmt,
+					 const Oid* argtypes,
+					 stub::placeholders_type& placeholders,
+					 StringInfo buf)
+{
+	appendStringInfoString(buf, "SELECT ");
+
+	bool first = true;
+	ListCell* lc;
+	foreach(lc, stmt->targetList)
+	{
+		ResTarget* res = lfirst_node(ResTarget, lc);
+
+		if (!first)
+			appendStringInfoString(buf, ", ");
+		first = false;
+
+		if (IsA(res->val, ColumnRef)) {
+			deparse_column_ref((ColumnRef*) res->val, res->name, buf);
+		}
+
+		if (IsA(res->val, FuncCall)) {
+			FuncCall* func = (FuncCall *) res->val;
+			ListCell* l;
+			foreach(l, func->funcname){
+				Node* name = (Node *) lfirst(l);
+				if (IsA(name, String)) {
+					appendStringInfo(buf, "%s", strVal(name));
+				}
+			}
+			appendStringInfoChar(buf, '(');
+			foreach(l, func->args){
+				Node* args = (Node *) lfirst(l);
+				if (IsA(args, ColumnRef)) {
+					deparse_column_ref((ColumnRef*) args, NULL, buf);
+				}
+			}
+			appendStringInfoChar(buf, ')');
+			if (res->name != NULL) {
+				appendStringInfo(buf, " AS \'%s\'", res->name);
+			}
+		}
+	}
+
+	if (stmt->fromClause != NULL) {
+		appendStringInfoString(buf, " FROM ");
+
+		ListCell* l;
+		foreach(l, stmt->fromClause)
+		{
+			Node* from = (Node *) lfirst(l);
+
+			if (IsA(from, RangeVar)) {
+				RangeVar* relation = (RangeVar *) from;
+				appendStringInfo(buf, "%s", relation->relname);
+				if (relation->alias != NULL) {
+					appendStringInfo(buf, " %s", relation->alias->aliasname);
+				}
+			}
+
+			if (IsA(from, JoinExpr)) {
+				deparse_join_expr((JoinExpr *)from, argtypes, placeholders, buf);
+			}
+		}
+	}
+
+	if (stmt->whereClause != NULL) {
+		appendStringInfoString(buf, " WHERE ");
+		deparse_where_clause(stmt->whereClause, argtypes, placeholders, buf);
+	}
+
+	if (stmt->sortClause != NULL) {
+		appendStringInfoString(buf, " ORDER BY ");
+		deparse_sort_clause(stmt->sortClause, buf);
+	}
+
+	if (stmt->groupClause != NULL) {
+		appendStringInfoString(buf, " GROUP BY ");
+		ListCell* l;
+		foreach(l, stmt->groupClause)
+		{
+			Node* group = (Node *) lfirst(l);
+			if (IsA(group, ColumnRef)) {
+				deparse_column_ref((ColumnRef*) group, NULL, buf);
+			}
+		}
+	}
+
+	if (stmt->havingClause != NULL) {
+		appendStringInfoString(buf, " HAVING ");
+		deparse_where_clause(stmt->havingClause, argtypes, placeholders, buf);
+	}
+}
+
+/**
+ *  @brief Calls the function to get ID and send created role ID to ogawayama.
+ *  @param [in] stmts of statements.
+ *  @return true if operation was successful, false otherwize.
+ */
+bool
+after_prepare_stmt(const PrepareStmt* stmts,
+				   const char* queryString)
+{
+	Assert(stmts != nullptr);
+
+	Node* query = stmts->query;
+	if (!is_tsurugi_table(query, true)) {
+		return true;
+	}
+
+	stub::placeholders_type placeholders{};
+	StringInfoData sql;
+	initStringInfo(&sql);
+
+	/* Transform list of TypeNames to array of type OIDs */
+	Oid* argtypes = nullptr;
+	std::vector<Oid> argtypes_v;
+	argtypes = transform_typenames_to_oids(stmts->argtypes, argtypes_v, queryString);
+
+	switch (nodeTag(query))
+	{
+		case T_InsertStmt:
+			{
+				deparse_insert_query((InsertStmt *)query, argtypes, placeholders, &sql);
+			}
+			break;
+		case T_UpdateStmt:
+			{
+				deparse_update_query((UpdateStmt *)query, argtypes, placeholders, &sql);
+			}
+			break;
+		case T_DeleteStmt:
+			{
+				deparse_delete_query((DeleteStmt *)query, argtypes, placeholders, &sql);
+			}
+			break;
+		case T_SelectStmt:
+			{
+				deparse_select_query((SelectStmt *)query, argtypes, placeholders, &sql);
+			}
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "unrecognized node type: %d",
+				 (int) nodeTag(query));
+			break;
+	}
+
+#if 1
+	stub::Connection* connection;
+	ERROR_CODE error = StubManager::get_connection(&connection);
+	if (error != ERROR_CODE::OK)
+	{
+		elog(ERROR, "StubManager::get_connection() failed. (code: %d)", (int) error);
+		return false;
+	}
+	error = connection->prepare(sql.data, placeholders, prepared_statement);
+	if (error != ERROR_CODE::OK)
+	{
+		elog(ERROR, "connection->prepare() failed. (%d)\n\tsql:%s", (int) error, sql.data);
+		return false;
+	}
+#else
+	PreparedStatementPtr prepared_statement;
+	ERROR_CODE error = Tsurugi::prepare(sql.data, placeholders, prepared_statement);
+	if (error != ERROR_CODE::OK)
+	{
+		elog(ERROR, "Tsurugi::prepare() failed. (%d)\n\tsql:%s", (int) error, sql.data);
+		return false;
+	}
+#endif
+
+	char* name = stmts->name;
+	stored_prepare_statment[std::string(name)] = std::move(prepared_statement);
+	stored_argtypes[std::string(name)] = argtypes_v;
+
+	return true;
+}
+
+void
+deparse_execute_param(const ExecuteStmt* stmts,
+					  const Param* target_param,
+					  const char* resname)
+{
+	List* stmt_params = stmts->params;
+	ListCell* lcp;
+	int param_count = 0;
+	foreach(lcp, stmt_params)
+	{
+		param_count++;
+		if (target_param->paramid == param_count) {
+			Node* stmt_param = (Node *) lfirst(lcp);
+			if (IsA(stmt_param, A_Const)) {
+				A_Const* con = (A_Const *)stmt_param;
+				Value* val = &con->val;
+				std::string col_name = resname;
+				col_name += "_" + std::to_string(target_param->paramid);
+				switch (nodeTag(val))
+				{
+					case T_Integer:
+					case T_Float:
+						{
+							switch (target_param->paramtype)
+							{
+								case INT2OID:
+									parameters.emplace_back(col_name,
+													static_cast<std::int16_t>(intVal(val)));
+									break;
+								case INT4OID:
+									parameters.emplace_back(col_name,
+													static_cast<std::int32_t>(intVal(val)));
+									break;
+								case INT8OID:
+									parameters.emplace_back(col_name,
+													static_cast<std::int64_t>(intVal(val)));
+									break;
+								case FLOAT4OID:
+									parameters.emplace_back(col_name,
+													static_cast<float>(floatVal(val)));
+									break;
+								case FLOAT8OID:
+									parameters.emplace_back(col_name,
+													static_cast<double>(floatVal(val)));
+									break;
+								default:
+									/* should not reach here */
+									elog(ERROR, "execute_param: unrecognized T_Integer paramtype oid: %d",
+										 (int) target_param->paramtype);
+									break;
+							}
+						}
+						break;
+					case T_String:
+#if 1
+						parameters.emplace_back(col_name, strVal(val));
+#else
+						switch (target_param->paramtype)
+						{
+							case BPCHAROID:
+							case VARCHAROID:
+							case TEXTOID:
+								parameters.emplace_back(col_name, strVal(val));
+								break;
+							case DATEOID:
+								stub::date_type value;
+								// ToDo: Transform strVal to takatori::datetime::date
+								break;
+							case TIMEOID:
+								stub::time_type value;
+								// ToDo: Transform strVal to takatori::datetime::time_of_day
+								break;
+							case TIMESTAMPOID:
+								stub::timestamp_type value;
+								// ToDo: Transform strVal to takatori::datetime::time_point
+								break;
+							default:
+								/* should not reach here */
+								elog(ERROR, "execute_param: unrecognized T_String paramtype oid: %d",
+									 (int) target_param->paramtype);
+								break;
+						}
+#endif
+						break;
+					case T_Null:
+						{
+							std::monostate monostate;
+							parameters.emplace_back(col_name, monostate);
+						}
+						break;
+					default:
+						/* should not reach here */
+						elog(ERROR, "execute_param: unrecognized a_const value node type: %d",
+							 (int) nodeTag(val));
+						break;
+				}
+			}
+		}
+	}
+}
+
+void
+deparse_execute_target_entry(const TargetEntry* target_entry,
+							 const ExecuteStmt* stmts)
+{
+	Expr* expr = target_entry->expr;
+
+	if (IsA(expr, Param)) {
+		Param* target_param = (Param *) expr;
+		deparse_execute_param(stmts, target_param, target_entry->resname);
+	} else if (IsA(expr, FuncExpr)) {
+		FuncExpr* func_expr = (FuncExpr *) expr;
+		List* args = func_expr->args;
+		ListCell* lca;
+		foreach(lca, args)
+		{
+			Node* arg = (Node *) lfirst(lca);
+			if (IsA(arg, Param)) {
+				Param* target_param = (Param *) arg;
+				deparse_execute_param(stmts, target_param, target_entry->resname);
+			}
+		}
+	}
+}
+
+void
+deparse_execute_paramref(const ParamRef* param_ref,
+						 std::string col_name,
+						 const ExecuteStmt* stmts)
+{
+	List* stmt_params = stmts->params;
+	ListCell* lcp;
+	int param_count = 0;
+	foreach(lcp, stmt_params)
+	{
+		param_count++;
+		if (param_ref->number == param_count) {
+			Node* stmt_param = (Node *) lfirst(lcp);
+			if (IsA(stmt_param, A_Const)) {
+				A_Const* con = (A_Const *)stmt_param;
+				Value* val = &con->val;
+				col_name += "_" + std::to_string(param_ref->number);
+				switch (nodeTag(val))
+				{
+					case T_Integer:
+					case T_Float:
+						{
+							std::vector<Oid> argtypes_v;
+							argtypes_v = stored_argtypes[stmts->name];
+							switch (argtypes_v[param_ref->number-1])
+							{
+								case INT2OID:
+									parameters.emplace_back(col_name,
+													static_cast<std::int16_t>(intVal(val)));
+									break;
+								case INT4OID:
+									parameters.emplace_back(col_name,
+													static_cast<std::int32_t>(intVal(val)));
+									break;
+								case INT8OID:
+									parameters.emplace_back(col_name,
+													static_cast<std::int64_t>(intVal(val)));
+									break;
+								case FLOAT4OID:
+									parameters.emplace_back(col_name,
+													static_cast<float>(floatVal(val)));
+									break;
+								case FLOAT8OID:
+									parameters.emplace_back(col_name,
+													static_cast<double>(floatVal(val)));
+									break;
+								default:
+									/* should not reach here */
+									elog(ERROR, "execute_paramref: unrecognized paramtype oid: %d",
+										 (int) argtypes_v[param_ref->number-1]);
+									break;
+							}
+						}
+						break;
+					case T_String:
+						parameters.emplace_back(col_name, strVal(val));
+						break;
+					default:
+						/* should not reach here */
+						elog(ERROR, "execute_paramref: unrecognized a_const value node type: %d",
+							 (int) nodeTag(val));
+						break;
+				}
+			}
+		}
+	}
+}
+
+bool
+deparse_execute_aexpr_op(A_Expr* a,
+						 const ExecuteStmt* stmts)
+{
+	Node* lexpr = a->lexpr;
+	Node* rexpr = a->rexpr;
+	std::string col_name;
+	bool result{true};
+
+	result = deparse_execute_expr_recurse(lexpr, col_name, stmts);
+	if (result != true) {
+		return result;
+	}
+
+	switch (list_length(a->name))
+	{
+		case 1:
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "deparse_execute_aexpr_op: list_length = %d", list_length(a->name));
+			result = false;
+			break;
+	}
+
+	result = deparse_execute_expr_recurse(rexpr, col_name, stmts);
+
+	return result;
+}
+
+bool
+deparse_execute_aexpr_between(A_Expr* a,
+							  const ExecuteStmt* stmts)
+{
+	Node* lexpr = a->lexpr;
+	List* rexpr = (List *) a->rexpr;
+	std::string col_name;
+	bool result{true};
+
+	result = deparse_execute_expr_recurse(lexpr, col_name, stmts);
+	if (result != true) {
+		return result;
+	}
+
+	switch (list_length(a->name))
+	{
+		case 1:
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "deparse_execute_aexpr_between: list_length = %d", list_length(a->name));
+			result = false;
+			return result;
+	}
+
+	ListCell   *lc;
+	int name_num = 0;
+	foreach(lc, rexpr)
+	{
+		Node* expr = (Node *) lfirst(lc);
+		std::string name = col_name + std::to_string(name_num);
+		result = deparse_execute_expr_recurse(expr, name, stmts);
+		if (result != true) {
+			return result;
+		}
+	}
+
+	return result;
+}
+
+bool
+deparse_execute_aexpr_like(A_Expr* a,
+						 const ExecuteStmt* stmts)
+{
+	Node* lexpr = a->lexpr;
+	Node* rexpr = a->rexpr;
+	std::string col_name;
+	bool result{true};
+
+	result = deparse_execute_expr_recurse(lexpr, col_name, stmts);
+	if (result != true) {
+		return result;
+	}
+
+	switch (list_length(a->name))
+	{
+		case 1:
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "deparse_execute_aexpr_like: list_length = %d", list_length(a->name));
+			result = false;
+			break;
+	}
+
+	result = deparse_execute_expr_recurse(rexpr, col_name, stmts);
+
+	return result;
+}
+
+bool
+deparse_execute_aexpr_in(A_Expr* a,
+						 const ExecuteStmt* stmts)
+{
+	Node* lexpr = a->lexpr;
+	List* rexpr = (List *) a->rexpr;
+	std::string col_name;
+	bool result{true};
+
+	result = deparse_execute_expr_recurse(lexpr, col_name, stmts);
+	if (result != true) {
+		return result;
+	}
+
+	switch (list_length(a->name))
+	{
+		case 1:
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "deparse_execute_aexpr_between: list_length = %d", list_length(a->name));
+			result = false;
+			return result;
+	}
+
+	ListCell   *lc;
+	int name_num = 0;
+	foreach(lc, rexpr)
+	{
+		Node* expr = (Node *) lfirst(lc);
+		std::string name = col_name + std::to_string(name_num);
+		result = deparse_execute_expr_recurse(expr, name, stmts);
+		if (result != true) {
+			return result;
+		}
+	}
+
+	return result;
+}
+
+bool
+deparse_execute_bool_expr(BoolExpr* a,
+						  const ExecuteStmt* stmts)
+{
+	ListCell   *lc;
+	bool result{true};
+
+	switch (a->boolop)
+	{
+		case AND_EXPR:
+		case OR_EXPR:
+		case NOT_EXPR:
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "deparse_execute_bool_expr: unrecognized boolop: %d", (int) a->boolop);
+			result = false;
+			return result;
+	}
+
+	foreach(lc, a->args)
+	{
+		Node* arg = (Node *) lfirst(lc);
+		deparse_execute_where_clause(arg, stmts);
+	}
+
+	return result;
+}
+
+bool
+deparse_execute_expr_recurse(Node* expr,
+							 std::string& col_name,
+							 const ExecuteStmt* stmts)
+{
+	bool result{true};
+
+	switch (nodeTag(expr))
+	{
+		case T_ColumnRef:
+			col_name = deparse_column_ref((ColumnRef*) expr, NULL, NULL);
+			break;
+
+		case T_ParamRef:
+			{
+				deparse_execute_paramref((ParamRef *)expr, col_name, stmts);
+				break;
+			}
+
+		case T_A_Expr:
+			{
+				A_Expr* a = (A_Expr *) expr;
+				switch (a->kind)
+				{
+					case AEXPR_OP:
+						result = deparse_execute_aexpr_op(a, stmts);
+						break;
+					case AEXPR_BETWEEN:
+						result = deparse_execute_aexpr_between(a, stmts);
+						break;
+					case AEXPR_LIKE:
+						result = deparse_execute_aexpr_like(a, stmts);
+						break;
+					case AEXPR_IN:
+						result = deparse_execute_aexpr_in(a, stmts);
+						break;
+					default:
+						/* should not reach here */
+						elog(ERROR, "unrecognized A_Expr kind: %d", a->kind);
+						result = false;
+						break;
+				}
+				break;
+			}
+
+		case T_BoolExpr:
+			result = deparse_execute_bool_expr((BoolExpr*) expr, stmts);
+			break;
+
+		case T_SubLink:
+			{
+				SubLink* sub_link = (SubLink *) expr;
+				SelectStmt* stmt = (SelectStmt *) sub_link->subselect;
+				deparse_execute_where_clause(stmt->whereClause, stmts);
+			}
+			break;
+
+		case T_A_Const:
+		case T_FuncCall:
+			/* EXECUTE does not require deparsing */
+			break;
+
+		default:
+			/* should not reach here */
+			elog(ERROR, "unrecognized expr node type: %d", (int) nodeTag(expr));
+			result = false;
+			break;
+	}
+
+	return result;
+}
+
+void
+deparse_execute_where_clause(const Node* expr,
+							 const ExecuteStmt* stmts)
+{
+	if (expr == NULL) {
+		return;
+	}
+
+	switch (nodeTag(expr))
+	{
+		case T_A_Expr:
+			{
+				A_Expr* a = (A_Expr *) expr;
+				switch (a->kind)
+				{
+					case AEXPR_OP:
+						deparse_execute_aexpr_op(a, stmts);
+						break;
+					case AEXPR_BETWEEN:
+						deparse_execute_aexpr_between(a, stmts);
+						break;
+					case AEXPR_LIKE:
+						deparse_execute_aexpr_like(a, stmts);
+						break;
+					case AEXPR_IN:
+						deparse_execute_aexpr_in(a, stmts);
+						break;
+					default:
+						/* should not reach here */
+						elog(ERROR, "unrecognized where clause A_Expr kind: %d", a->kind);
+						break;
+				}
+				break;
+			}
+
+		case T_BoolExpr:
+			deparse_execute_bool_expr((BoolExpr*) expr, stmts);
+			break;
+
+		case T_SubLink:
+			{
+				SubLink* sub_link = (SubLink *) expr;
+				SelectStmt* stmt = (SelectStmt *) sub_link->subselect;
+				deparse_execute_where_clause(stmt->whereClause, stmts);
+			}
+			break;
+
+		default:
+			/* should not reach here */
+			elog(ERROR, "unrecognized where clause expr node type: %d", (int) nodeTag(expr));
+			break;
+	}
+}
+
+bool
+befor_execute_stmt(const ExecuteStmt* stmts)
+{
+	PreparedStatement* entry;
+	List* query_list;
+	ListCell* l;
+
+	entry = FetchPreparedStatement(stmts->name, true);
+
+	RawStmt* raw_stmt = entry->plansource->raw_parse_tree;
+	Node* query = raw_stmt->stmt;
+	if (!is_tsurugi_table(query, false)) {
+		return true;
+	}
+
+	query_list = entry->plansource->query_list;
+	foreach(l, query_list)
+	{
+		Query* query = (Query *) lfirst(l);
+		List* target_list = query->targetList;
+		ListCell* lc;
+		foreach(lc, target_list)
+		{
+			TargetEntry* target_entry = (TargetEntry *) lfirst(lc);
+			deparse_execute_target_entry(target_entry, stmts);
+		}
+	}
+
+	switch (nodeTag(raw_stmt->stmt))
+	{
+		case T_InsertStmt:
+			break;
+		case T_UpdateStmt:
+			{
+				UpdateStmt* stmt = (UpdateStmt *) raw_stmt->stmt;
+				deparse_execute_where_clause(stmt->whereClause, stmts);
+			}
+			break;
+		case T_DeleteStmt:
+			{
+				DeleteStmt* stmt = (DeleteStmt *) raw_stmt->stmt;
+				deparse_execute_where_clause(stmt->whereClause, stmts);
+			}
+			break;
+		case T_SelectStmt:
+			{
+				SelectStmt* stmt = (SelectStmt *) raw_stmt->stmt;
+
+				if (stmt->fromClause != NULL) {
+					ListCell* l;
+					foreach(l, stmt->fromClause)
+					{
+						Node* from = (Node *) lfirst(l);
+						if (IsA(from, JoinExpr)) {
+							JoinExpr* join = (JoinExpr *) from;
+							deparse_execute_where_clause(join->quals, stmts);
+						}
+					}
+				}
+				deparse_execute_where_clause(stmt->whereClause, stmts);
+				deparse_execute_where_clause(stmt->havingClause, stmts);
+			}
+			break;
+		default:
+			/* should not reach here */
+			elog(ERROR, "unrecognized where clause node type: %d",
+				 (int) nodeTag(raw_stmt->stmt));
+			break;
+	}
+
+	prepared_statement = std::move(stored_prepare_statment.at(stmts->name));
+
+	return true;
+}
+
+bool
+after_execute_stmt(const ExecuteStmt* stmts)
+{
+	PreparedStatement* entry = FetchPreparedStatement(stmts->name, true);
+	RawStmt* raw_stmt = entry->plansource->raw_parse_tree;
+	Node* query = raw_stmt->stmt;
+	if (!is_tsurugi_table(query, false)) {
+		return true;
+	}
+
+	stored_prepare_statment[stmts->name] = std::move(prepared_statement);
+	parameters = {};
+	return true;
+}

--- a/alt_utility/prepare_execute/prepare_execute.h
+++ b/alt_utility/prepare_execute/prepare_execute.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 tsurugi project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *	@file	prepare_execute.h
+ *	@brief  Dispatch the prepare command to ogawayama.
+ */
+
+#ifndef PREPARE_EXECUTE_H
+#define PREPARE_EXECUTE_H
+
+#ifdef __cplusplus
+extern "C" {
+
+#endif
+
+bool after_prepare_stmt(const PrepareStmt* stmts, const char* queryString);
+bool befor_execute_stmt(const ExecuteStmt* stmts);
+bool after_execute_stmt(const ExecuteStmt* stmts);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // PREPARE_EXECUTE_H

--- a/docs/design/Transaction/sample/transaction_sample.java
+++ b/docs/design/Transaction/sample/transaction_sample.java
@@ -1,0 +1,84 @@
+/* java.sql パッケージをインポート */
+import java.sql.*;
+
+class transaction_sample {
+    public static void main(String[] args) throws Exception {
+
+        /* JDBCドライバの読み込み */
+        Class.forName("org.postgresql.Driver");
+
+        /* データベース(PostgreSQL)の接続先 */
+        String url = "jdbc:postgresql://localhost:35432/postgres";
+        try {
+
+            /* データベース(PostgreSQL)へ接続する */
+            Connection conn = DriverManager.getConnection(url);
+
+            /* Statementを使用してTsurugiのトランザクションを制御する */
+            Statement st = conn.createStatement();
+
+            // Drop Table
+            try {
+                st.execute("DROP FOREIGN TABLE tg_sample");
+                st.execute("DROP TABLE tg_sample");
+            } catch (SQLException e) {
+                System.out.println("Drop Table error");
+                System.out.println("CATCH SQLException e.getMessage = " + e.getMessage());
+            }
+
+            // Create Table
+            try {
+                st.execute(
+                            "CREATE TABLE tg_sample ("
+                                + "col INTEGER NOT NULL PRIMARY KEY"
+                                + ") TABLESPACE tsurugi"
+                          );
+                st.execute(
+                            "CREATE FOREIGN TABLE tg_sample ("
+                                + "col INTEGER NOT NULL"
+                                + ") SERVER ogawayama"
+                          );
+            } catch (SQLException e) {
+                System.out.println("Create Table error");
+                System.out.println("CATCH SQLException e.getMessage = " + e.getMessage());
+            }
+
+            /* PreparedStatementを使用してTsurugiのテーブルにデータを挿入する */
+            String sql = "INSERT INTO tg_sample (col) VALUES (?)";
+            PreparedStatement ps = conn.prepareStatement(sql);
+
+            for (int i=0; i<9; i++) {
+
+                /* Tsurugiのトランザクションを開始する */
+                st.execute("SELECT tg_start_transaction()");
+
+                /* Tsurugiのテーブルにデータ(i)を挿入する */
+                ps.setInt(1, i);
+                ps.executeUpdate();
+
+                /* 挿入した値(i)が偶数か奇数か判定 */
+                if (i % 2 == 0) {
+                    /* 偶数の場合：トランザクションをコミットする */
+                    st.execute("SELECT tg_commit()");
+                } else {
+                    /* 奇数の場合：トランザクションをロールバックする */
+                    st.execute("SELECT tg_rollback()");
+                }
+
+            }
+
+            /* 実行結果を確認する */
+            ResultSet rs = st.executeQuery("SELECT * FROM tg_sample");
+            System.out.println("--- 実行結果：奇数は破棄(ロールバック)される ---");
+            while (rs.next()) {
+                System.out.println("  " + rs.getString(1));
+            }
+
+            ps.close();
+            st.close();
+            conn.close();
+        } catch (SQLException e) {
+            System.out.println("CATCH SQLException e.getMessage = " + e.getMessage());
+        }
+    }
+}

--- a/expected/prepare_select_statment.out
+++ b/expected/prepare_select_statment.out
@@ -1,0 +1,1038 @@
+/***********/
+/*** DDL ***/
+/***********/
+-- TG tables
+CREATE TABLE t1(
+    c1 INTEGER PRIMARY KEY, 
+    c2 INTEGER, 
+    c3 BIGINT,
+    c4 REAL, 
+    c5 DOUBLE PRECISION, 
+    c6 CHAR(10),
+    c7 VARCHAR(26)
+) TABLESPACE tsurugi;
+CREATE FOREIGN TABLE t1(
+    c1 INTEGER, 
+    c2 INTEGER, 
+    c3 BIGINT,
+    c4 REAL, 
+    c5 DOUBLE PRECISION, 
+    c6 CHAR(10),
+    c7 VARCHAR(26)
+) SERVER ogawayama;
+CREATE TABLE t2(
+    c1 INTEGER PRIMARY KEY, 
+    c2 INTEGER, 
+    c3 BIGINT,
+    c4 REAL, 
+    c5 DOUBLE PRECISION, 
+    c6 CHAR(10),
+    c7 VARCHAR(26)
+) TABLESPACE tsurugi;
+CREATE FOREIGN TABLE t2(
+    c1 INTEGER, 
+    c2 INTEGER, 
+    c3 BIGINT,
+    c4 REAL, 
+    c5 DOUBLE PRECISION, 
+    c6 CHAR(10),
+    c7 VARCHAR(26)
+) SERVER ogawayama;
+CREATE TABLE t3(
+    c1 INTEGER PRIMARY KEY,
+    c2 CHAR(10)
+) TABLESPACE tsurugi;
+CREATE FOREIGN TABLE t3(
+    c1 INTEGER,
+    c2 CHAR(10)
+) SERVER ogawayama;
+-- PG tables
+CREATE TABLE pt1(
+    c1 INTEGER PRIMARY KEY, 
+    c2 INTEGER, 
+    c3 BIGINT,
+    c4 REAL, 
+    c5 DOUBLE PRECISION, 
+    c6 CHAR(10),
+    c7 VARCHAR(26)
+);
+CREATE TABLE pt2(
+    c1 INTEGER PRIMARY KEY, 
+    c2 INTEGER, 
+    c3 BIGINT,
+    c4 REAL, 
+    c5 DOUBLE PRECISION, 
+    c6 CHAR(10),
+    c7 VARCHAR(26)
+);
+CREATE TABLE pt3(
+    c1 INTEGER PRIMARY KEY,
+    c2 CHAR(10)
+);
+/***************/
+/*** PREPARE ***/
+/***************/
+-- TG tables
+PREPARE insert_t1 (INTEGER, INTEGER, BIGINT, REAL, DOUBLE PRECISION, CHAR(10), VARCHAR(26)) 
+    AS INSERT INTO t1 (c1, c2, c3, c4, c5, c6, c7) VALUES ($1, $2, $3, $4, $5, $6, $7);
+PREPARE select_t1_all 
+	AS SELECT * FROM t1;
+PREPARE insert_t2 (INTEGER, INTEGER, BIGINT, REAL, DOUBLE PRECISION, CHAR(10), VARCHAR(26)) 
+    AS INSERT INTO t2 (c1, c2, c3, c4, c5, c6, c7) VALUES ($1, $2, $3, $4, $5, $6, $7);
+PREPARE select_t2_all 
+	AS SELECT * FROM t2;
+PREPARE insert_t3 (INTEGER, CHAR(10)) 
+    AS INSERT INTO t3 (c1, c2) VALUES ($1, $2);
+PREPARE select_t3_all 
+	AS SELECT * FROM t3;
+-- PG tables
+PREPARE insert_pt1 (INTEGER, INTEGER, BIGINT, REAL, DOUBLE PRECISION, CHAR(10), VARCHAR(26)) 
+    AS INSERT INTO pt1 (c1, c2, c3, c4, c5, c6, c7) VALUES ($1, $2, $3, $4, $5, $6, $7);
+PREPARE select_pt1_all 
+	AS SELECT * FROM pt1;
+PREPARE insert_pt2 (INTEGER, INTEGER, BIGINT, REAL, DOUBLE PRECISION, CHAR(10), VARCHAR(26)) 
+    AS INSERT INTO pt2 (c1, c2, c3, c4, c5, c6, c7) VALUES ($1, $2, $3, $4, $5, $6, $7);
+PREPARE select_pt2_all 
+	AS SELECT * FROM pt2;
+PREPARE insert_pt3 (INTEGER, CHAR(10)) 
+    AS INSERT INTO pt3 (c1, c2) VALUES ($1, $2);
+PREPARE select_pt3_all 
+	AS SELECT * FROM pt3;
+-- SELECT
+-- PG
+PREPARE select_pt2_c2_c4_c6
+	AS SELECT c2, c4, c6 FROM pt2;
+-- TG
+PREPARE select_t2_c2_c4_c6
+	AS SELECT c2, c4, c6 FROM t2;
+-- PG
+PREPARE select_pt2_c6
+	AS SELECT c6 FROM pt2;
+-- TG
+PREPARE select_t2_c6
+	AS SELECT c6 FROM t2;
+-- PG
+PREPARE select_pt2_c1_c2_seisu
+	AS SELECT c1, c2 AS seisu FROM pt2;
+-- TG
+PREPARE select_t2_c1_c2_seisu
+	AS SELECT c1, c2 AS seisu FROM t2;
+-- ORDER BY #1
+-- PG
+PREPARE select_pt2_orderby1
+	AS SELECT * FROM pt2 ORDER BY c6;
+-- TG
+PREPARE select_t2_orderby1
+	AS SELECT * FROM t2 ORDER BY c6;
+-- ORDER BY #2
+-- PG
+PREPARE select_pt2_orderby2
+	AS SELECT c1, c2, c3, c4, c5, c6, c7 FROM pt2 ORDER BY 6;
+-- TG
+/* failed (10) because of ORDER BY 6 */
+PREPARE select_t2_orderby2
+	AS SELECT c1, c2, c3, c4, c5, c6, c7 FROM t2 ORDER BY 6;
+ERROR:  connection->prepare() failed. (10)
+	sql:SELECT c1, c2, c3, c4, c5, c6, c7 FROM t2 ORDER BY 6 
+-- ORDER BY #3
+-- PG
+PREPARE select_pt2_orderby3
+	AS SELECT c1, c4, c5, c6, c7 FROM pt2 WHERE c1 > 2 ORDER BY c7;
+-- TG
+PREPARE select_t2_orderby3
+	AS SELECT c1, c4, c5, c6, c7 FROM t2 WHERE c1 > 2 ORDER BY c7;
+-- ORDER BY #4
+-- PG
+PREPARE select_pt2_orderby4
+	AS SELECT c1, c2 FROM pt2 WHERE c2 * 2 > 50 ORDER BY c3 DESC;
+-- TG
+PREPARE select_t2_orderby4
+	AS SELECT c1, c2 FROM t2 WHERE c2 * 2 > 50 ORDER BY c3 DESC;
+-- WHERE #1
+-- PG
+PREPARE select_pt2_where1
+	AS SELECT * FROM pt2 WHERE c3 > 2 ORDER BY c1;
+-- TG
+PREPARE select_t2_where1
+	AS SELECT * FROM t2 WHERE c3 > 2 ORDER BY c1;
+-- WHERE #2
+-- PG
+PREPARE select_pt2_where2
+	AS SELECT * FROM pt2 WHERE c7 = 'XYZ' ORDER BY c1;
+-- TG
+PREPARE select_t2_where2
+	AS SELECT * FROM t2 WHERE c7 = 'XYZ' ORDER BY c1;
+-- WHERE #3
+-- PG
+PREPARE select_pt1_where3
+	AS SELECT c1, c2, c6, c7 FROM pt1 WHERE c1 = 1 OR c1 = 3;
+-- TG
+PREPARE select_t1_where3
+	AS SELECT c1, c2, c6, c7 FROM t1 WHERE c1 = 1 OR c1 = 3;
+-- WHERE #4
+-- PG
+PREPARE select_pt1_where4
+	AS SELECT c1, c3, c5, c7 FROM pt1 WHERE c1 = 2;
+-- TG
+PREPARE select_t1_where4
+	AS SELECT c1, c3, c5, c7 FROM t1 WHERE c1 = 2;
+-- WHERE #5
+-- PG
+PREPARE select_pt1_where5
+	AS SELECT * FROM pt1 WHERE c4 >= 2.2 AND c4 < 5.5;
+-- TG
+PREPARE select_t1_where5
+	AS SELECT * FROM t1 WHERE c4 >= 2.2 AND c4 < 5.5;
+-- WHERE #6
+-- PG
+PREPARE select_pt2_where6
+	AS SELECT * FROM pt2 WHERE c4 BETWEEN 2.2 AND 5.5;
+-- TG
+/* tsurugi-issue#69 */
+PREPARE select_t2_where6
+	AS SELECT * FROM t2 WHERE c4 BETWEEN 2.2 AND 5.5;
+ERROR:  connection->prepare() failed. (10)
+	sql:SELECT * FROM t2 WHERE c4 BETWEEN 2.200000 AND 5.500000 
+-- WHERE #7
+-- PG
+PREPARE select_pt1_where7
+	AS SELECT * FROM pt1 WHERE c7 LIKE '%LMN%';
+-- TG
+/* tsurugi-issue#103 */
+PREPARE select_t1_where7
+	AS SELECT * FROM t1 WHERE c7 LIKE '%LMN%';
+-- WHERE #8
+-- PG
+PREPARE select_pt1_where8
+	AS SELECT * FROM pt1 WHERE EXISTS (SELECT * FROM pt2 WHERE c2 = 22);
+-- TG
+/* not support EXISTS failed. (10) */
+PREPARE select_t1_where8
+	AS SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t2 WHERE c2 = 22);
+ERROR:  connection->prepare() failed. (10)
+	sql:SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t2 WHERE c2 = 22 )
+-- WHERE #9
+-- PG
+PREPARE select_pt2_where9
+	AS SELECT * FROM pt2 WHERE c4 IN (1.1,3.3);
+-- TG
+/* tsurugi-issue#70 */
+PREPARE select_t2_where9
+	AS SELECT * FROM t2 WHERE c4 IN (1.1,3.3);
+ERROR:  connection->prepare() failed. (10)
+	sql:SELECT * FROM t2 WHERE c4 IN (1.100000 , 3.300000 )
+-- GROUP BY #1
+-- PG
+PREPARE select_pt2_group1
+	AS SELECT count(c1) AS "count(c1)", sum(c2) AS "sum(c2)", c7 FROM pt2 GROUP BY c7;
+-- TG
+/* aggregate functions alias not support failed. (10) */
+PREPARE select_t2_group1_ng
+	AS SELECT count(c1) AS "count(c1)", sum(c2) AS "sum(c2)", c7 FROM t2 GROUP BY c7;
+ERROR:  connection->prepare() failed. (10)
+	sql:SELECT count(c1) AS 'count(c1)', sum(c2) AS 'sum(c2)', c7 FROM t2 GROUP BY c7
+PREPARE select_t2_group1
+	AS SELECT count(c1), sum(c2), c7 FROM t2 GROUP BY c7;
+-- GROUP BY #2
+-- PG
+PREPARE select_pt2_group2
+	AS SELECT count(c1) AS "count(c1)", sum(c2) AS "sum(c2)", c7 FROM pt2 GROUP BY c7 HAVING sum(c2) > 55;
+-- TG
+/* aggregate functions alias not support failed. (10) */
+PREPARE select_t2_group2_ng1
+	AS SELECT count(c1) AS "count(c1)", sum(c2) AS "sum(c2)", c7 FROM t2 GROUP BY c7 HAVING sum(c2) > 55;
+ERROR:  connection->prepare() failed. (10)
+	sql:SELECT count(c1) AS 'count(c1)', sum(c2) AS 'sum(c2)', c7 FROM t2 GROUP BY c7 HAVING sum(c2) > 55 
+/* having not support failed. (10) */
+PREPARE select_t2_group2_ng2
+	AS SELECT count(c1), sum(c2), c7 FROM t2 GROUP BY c7 HAVING sum(c2) > 55;
+ERROR:  connection->prepare() failed. (10)
+	sql:SELECT count(c1), sum(c2), c7 FROM t2 GROUP BY c7 HAVING sum(c2) > 55 
+-- GROUP BY #3
+-- PG
+PREPARE select_pt2_group3
+	AS SELECT c7, count(c1), sum(c2), avg(c3), min(c4), max(c5) FROM pt2 GROUP BY c7;
+-- TG
+PREPARE select_t2_group3_exe_ng1
+	AS SELECT c7, count(c1), sum(c2), avg(c3), min(c4), max(c5) FROM t2 GROUP BY c7;
+-- FOREIGN TABLE JOIN
+-- TG JOIN #1
+PREPARE select_join1
+	AS SELECT * FROM t1 a INNER JOIN t2 b ON a.c1 = b.c1 WHERE b.c1 > 1;
+-- TG JOIN #2
+/* failed (10) : mismatched input 'USING' */
+PREPARE select_join2
+	AS SELECT a.c1, a.c2, b.c1, b.c7 FROM t1 a INNER JOIN t2 b USING (c1) ORDER BY b.c4 DESC;
+ERROR:  connection->prepare() failed. (10)
+	sql:SELECT a.c1, a.c2, b.c1, b.c7 FROM t1 a CROSS JOIN t2 b USING (c1) ORDER BY b.c4 DESC
+-- TG JOIN #3
+PREPARE select_join3
+	AS SELECT a.c1, a.c3, b.c1, b.c6 FROM t1 a INNER JOIN t2 b ON a.c1 != b.c1;
+-- POSTGRESQL TABLE JOIN
+-- PG JOIN #1
+-- PG
+PREPARE select_pg_join_pg1
+	AS SELECT * FROM pt1 a INNER JOIN pt2 b ON a.c4 = b.c4 WHERE a.c1 > 1;
+-- TG
+/* tables are mixed */
+PREPARE select_pg_join_tg1
+	AS SELECT * FROM t1 a INNER JOIN pt2 b ON a.c4 = b.c4 WHERE a.c1 > 1;
+WARNING:  If Tsurugi and non-Tsurugi tables are mixed, do not PREPARE to Tsurugi
+-- PG JOIN #2
+-- PG
+PREPARE select_pg_join_pg2
+	AS SELECT a.c1, a.c2, b.c4, b.c6 FROM pt1 a INNER JOIN pt2 b USING (c1) ORDER BY b.c4 DESC;
+-- TG
+/* tables are mixed */
+PREPARE select_pg_join_tg2
+	AS SELECT a.c1, a.c2, b.c4, b.c6 FROM t1 a INNER JOIN pt2  b USING (c1) ORDER BY b.c4 DESC;
+WARNING:  If Tsurugi and non-Tsurugi tables are mixed, do not PREPARE to Tsurugi
+-- PG JOIN  #3
+-- PG
+PREPARE select_pg_join_pg3
+	AS SELECT a.c1, a.c3, b.c5, b.c7 FROM pt2 a LEFT OUTER JOIN pt1 b ON a.c1 = b.c1;
+-- TG
+/* tables are mixed */
+PREPARE select_pg_join_tg3
+	AS SELECT a.c1, a.c3, b.c5, b.c7 FROM t2 a LEFT OUTER JOIN pt1 b ON a.c1 = b.c1;
+WARNING:  If Tsurugi and non-Tsurugi tables are mixed, do not PREPARE to Tsurugi
+-- PG JOIN #4
+-- PG
+PREPARE select_pg_join_pg4
+	AS SELECT * FROM pt1 a INNER JOIN pt2 b ON a.c4 = b.c4 WHERE a.c1 > 1 AND a.c1 < 3;
+-- TG
+/* tables are mixed */
+PREPARE select_pg_join_tg4
+	AS SELECT * FROM pt1 a INNER JOIN t2 b ON a.c4 = b.c4 WHERE a.c1 > 1 AND a.c1 < 3;
+WARNING:  If Tsurugi and non-Tsurugi tables are mixed, do not PREPARE to Tsurugi
+-- PG JOIN #5
+-- PG
+PREPARE select_pg_join_pg5
+	AS SELECT count(a.c1), sum(b.c2), b.c7 FROM pt1 a INNER JOIN pt2 b USING (c2) GROUP BY b.c7;
+-- TG
+/* tables are mixed */
+PREPARE select_pg_join_tg5
+	AS SELECT count(a.c1), sum(b.c2), b.c7 FROM pt1 a INNER JOIN t2 b USING (c2) GROUP BY b.c7;
+WARNING:  If Tsurugi and non-Tsurugi tables are mixed, do not PREPARE to Tsurugi
+-- PG JOIN #6
+-- PG
+PREPARE select_pg_join_pg6
+	AS SELECT * FROM pt1 AS a JOIN pt2 AS b ON a.c4=b.c4 JOIN pt1 AS c ON b.c4=c.c4 WHERE a.c2=22;
+-- TG
+PREPARE select_pg_join_tg6
+	AS SELECT * FROM t1 AS a JOIN t2 AS b ON a.c4=b.c4 JOIN t1 AS c ON b.c4=c.c4 WHERE a.c2=22;
+-- PG&TG
+/* tables are mixed */
+PREPARE select_pg_join_pgtg6
+	AS SELECT * FROM t1 AS a JOIN pt2 AS b ON a.c4=b.c4 JOIN t1 AS c ON b.c4=c.c4 WHERE a.c2=22;
+WARNING:  If Tsurugi and non-Tsurugi tables are mixed, do not PREPARE to Tsurugi
+-- PG JOIN #7
+-- PG
+PREPARE select_pg_join_pg7
+	AS SELECT * FROM pt1 AS a CROSS JOIN pt2 AS b ORDER BY b.c1;
+-- TG
+PREPARE select_pg_join_tg7
+	AS SELECT * FROM t1 AS a CROSS JOIN t2 AS b ORDER BY b.c1;
+-- PG&TG
+/* tables are mixed */
+PREPARE select_pg_join_pgtg7
+	AS SELECT * FROM pt1 AS a CROSS JOIN t2 AS b ORDER BY b.c1;
+WARNING:  If Tsurugi and non-Tsurugi tables are mixed, do not PREPARE to Tsurugi
+-- PG JOIN #8
+-- PG
+PREPARE select_pg_join_pg8
+	AS SELECT * FROM pt1 AS a JOIN pt1 AS b ON a.c3=b.c3;
+-- TG
+PREPARE select_pg_join_tg8
+	AS SELECT * FROM t1 AS a JOIN t1 AS b ON a.c3=b.c3;
+/***************/
+/*** EXECUTE ***/
+/***************/
+-- TG tables
+EXECUTE insert_t1 (1, 11, 111, 1.1, 1.11, 'first', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+EXECUTE insert_t1 (2, 22, 222, 2.2, 2.22, 'second', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+EXECUTE insert_t1 (3, 33, 333, 3.3, 3.33, 'third', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+EXECUTE select_t1_all;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             
+----+----+-----+-----+------+------------+----------------------------
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(3 rows)
+
+EXECUTE insert_t2 (1, 11, 111, 1.1, 1.11, 'one', 'ABC');
+EXECUTE insert_t2 (2, 22, 222, 2.2, 2.22, 'two', 'XYZ');
+EXECUTE insert_t2 (3, 33, 333, 3.3, 3.33, 'three', 'ABC');
+EXECUTE insert_t2 (4, NULL, NULL, NULL, NULL, 'NULL', NULL);
+EXECUTE insert_t2 (5, 55, 555, 5.5, 5.55, 'five', 'XYZ');
+EXECUTE select_t2_all;
+ c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+-----
+  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  4 |    |     |     |      | NULL       | 
+  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+(5 rows)
+
+EXECUTE insert_t3 (1, 'ichi');
+EXECUTE insert_t3 (2, 'ni');
+EXECUTE insert_t3 (3, 'san');
+EXECUTE insert_t3 (4, 'si');
+EXECUTE insert_t3 (5, 'go');
+EXECUTE select_t3_all;
+ c1 |     c2     
+----+------------
+  1 | ichi      
+  2 | ni        
+  3 | san       
+  4 | si        
+  5 | go        
+(5 rows)
+
+-- PG tables
+EXECUTE insert_pt1 (1, 11, 111, 1.1, 1.11, 'first', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+EXECUTE insert_pt1 (2, 22, 222, 2.2, 2.22, 'second', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+EXECUTE insert_pt1 (3, 33, 333, 3.3, 3.33, 'third', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+EXECUTE select_pt1_all;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             
+----+----+-----+-----+------+------------+----------------------------
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(3 rows)
+
+EXECUTE insert_pt2 (1, 11, 111, 1.1, 1.11, 'one', 'ABC');
+EXECUTE insert_pt2 (2, 22, 222, 2.2, 2.22, 'two', 'XYZ');
+EXECUTE insert_pt2 (3, 33, 333, 3.3, 3.33, 'three', 'ABC');
+EXECUTE insert_pt2 (4, NULL, NULL, NULL, NULL, 'NULL', NULL);
+EXECUTE insert_pt2 (5, 55, 555, 5.5, 5.55, 'five', 'XYZ');
+EXECUTE select_pt2_all;
+ c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+-----
+  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  4 |    |     |     |      | NULL       | 
+  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+(5 rows)
+
+EXECUTE insert_pt3 (1, 'ichi');
+EXECUTE insert_pt3 (2, 'ni');
+EXECUTE insert_pt3 (3, 'san');
+EXECUTE insert_pt3 (4, 'si');
+EXECUTE insert_pt3 (5, 'go');
+EXECUTE select_pt3_all;
+ c1 |     c2     
+----+------------
+  1 | ichi      
+  2 | ni        
+  3 | san       
+  4 | si        
+  5 | go        
+(5 rows)
+
+-- SELECT
+-- PG
+EXECUTE select_pt1_all;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             
+----+----+-----+-----+------+------------+----------------------------
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(3 rows)
+
+-- TG
+EXECUTE select_t1_all;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             
+----+----+-----+-----+------+------------+----------------------------
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(3 rows)
+
+-- PG
+EXECUTE select_pt2_c2_c4_c6;
+ c2 | c4  |     c6     
+----+-----+------------
+ 11 | 1.1 | one       
+ 22 | 2.2 | two       
+ 33 | 3.3 | three     
+    |     | NULL      
+ 55 | 5.5 | five      
+(5 rows)
+
+-- TG
+EXECUTE select_t2_c2_c4_c6;
+ c2 | c4  |     c6     
+----+-----+------------
+ 11 | 1.1 | one       
+ 22 | 2.2 | two       
+ 33 | 3.3 | three     
+    |     | NULL      
+ 55 | 5.5 | five      
+(5 rows)
+
+-- PG
+EXECUTE select_pt2_c6;
+     c6     
+------------
+ one       
+ two       
+ three     
+ NULL      
+ five      
+(5 rows)
+
+-- TG
+EXECUTE select_t2_c6;
+     c6     
+------------
+ one       
+ two       
+ three     
+ NULL      
+ five      
+(5 rows)
+
+-- PG
+EXECUTE select_pt2_c1_c2_seisu;
+ c1 | seisu 
+----+-------
+  1 |    11
+  2 |    22
+  3 |    33
+  4 |      
+  5 |    55
+(5 rows)
+
+-- TG
+EXECUTE select_t2_c1_c2_seisu;
+ c1 | seisu 
+----+-------
+  1 |    11
+  2 |    22
+  3 |    33
+  4 |      
+  5 |    55
+(5 rows)
+
+-- ORDER BY #1
+-- PG
+EXECUTE select_pt2_orderby1;
+ c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+-----
+  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+  4 |    |     |     |      | NULL       | 
+  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+(5 rows)
+
+-- TG
+EXECUTE select_t2_orderby1;
+ c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+-----
+  4 |    |     |     |      | NULL       | 
+  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+(5 rows)
+
+-- ORDER BY #2
+-- PG
+EXECUTE select_pt2_orderby2;
+ c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+-----
+  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+  4 |    |     |     |      | NULL       | 
+  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+(5 rows)
+
+-- TG
+/* failed (10) because of ORDER BY 6
+EXECUTE select_t2_orderby2;
+*/
+-- ORDER BY #3
+-- PG
+EXECUTE select_pt2_orderby3;
+ c1 | c4  |  c5  |     c6     | c7  
+----+-----+------+------------+-----
+  3 | 3.3 | 3.33 | three      | ABC
+  5 | 5.5 | 5.55 | five       | XYZ
+  4 |     |      | NULL       | 
+(3 rows)
+
+-- TG
+EXECUTE select_t2_orderby3;
+ c1 | c4  |  c5  |     c6     | c7  
+----+-----+------+------------+-----
+  4 |     |      | NULL       | 
+  3 | 3.3 | 3.33 | three      | ABC
+  5 | 5.5 | 5.55 | five       | XYZ
+(3 rows)
+
+-- ORDER BY #4
+-- PG
+EXECUTE select_pt2_orderby4;
+ c1 | c2 
+----+----
+  5 | 55
+  3 | 33
+(2 rows)
+
+-- TG
+EXECUTE select_t2_orderby4;
+ c1 | c2 
+----+----
+  5 | 55
+  3 | 33
+(2 rows)
+
+-- WHERE #1
+-- WHERE #1
+-- PG
+EXECUTE select_pt2_where1;
+ c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+-----
+  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+(4 rows)
+
+-- TG
+EXECUTE select_t2_where1;
+ c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+-----
+  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+(4 rows)
+
+-- WHERE #2
+-- PG
+EXECUTE select_pt2_where2;
+ c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+-----
+  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+(2 rows)
+
+-- TG
+EXECUTE select_t2_where2;
+ c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+-----
+  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+(2 rows)
+
+-- WHERE #3
+-- PG
+EXECUTE select_pt1_where3;
+ c1 | c2 |     c6     |             c7             
+----+----+------------+----------------------------
+  1 | 11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  3 | 33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(2 rows)
+
+-- TG
+EXECUTE select_t1_where3;
+ c1 | c2 |     c6     |             c7             
+----+----+------------+----------------------------
+  1 | 11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  3 | 33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(2 rows)
+
+-- WHERE #4
+-- PG
+EXECUTE select_pt1_where4;
+ c1 | c3  |  c5  |             c7             
+----+-----+------+----------------------------
+  2 | 222 | 2.22 | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(1 row)
+
+-- TG
+EXECUTE select_t1_where4;
+ c1 | c3  |  c5  |             c7             
+----+-----+------+----------------------------
+  2 | 222 | 2.22 | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(1 row)
+
+-- WHERE #5
+-- PG
+EXECUTE select_pt1_where5;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             
+----+----+-----+-----+------+------------+----------------------------
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(2 rows)
+
+-- TG
+EXECUTE select_t1_where5;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             
+----+----+-----+-----+------+------------+----------------------------
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(2 rows)
+
+-- WHERE #6
+-- PG
+EXECUTE select_pt2_where6;
+ c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+-----
+  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+(3 rows)
+
+-- TG
+/* tsurugi-issue#69
+EXECUTE select_t2_where6;
+*/
+-- WHERE #7
+-- PG
+EXECUTE select_pt1_where7;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             
+----+----+-----+-----+------+------------+----------------------------
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(3 rows)
+
+-- TG
+/* tsurugi-issue#103 */
+EXECUTE select_t1_where7;
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 
+----+----+----+----+----+----+----
+(0 rows)
+
+-- WHERE #8
+-- PG
+EXECUTE select_pt1_where8;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             
+----+----+-----+-----+------+------------+----------------------------
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(3 rows)
+
+-- TG
+/* not support EXISTS failed. (10)
+EXECUTE select_t1_where8;
+*/
+-- WHERE #9
+-- PG
+EXECUTE select_pt2_where9;
+ c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+-----
+  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+(2 rows)
+
+-- TG
+/* tsurugi-issue#70
+EXECUTE select_t2_where9;
+*/
+-- GROUP BY #1
+-- PG
+EXECUTE select_pt2_group1;
+ count(c1) | sum(c2) | c7  
+-----------+---------+-----
+         1 |         | 
+         2 |      44 | ABC
+         2 |      77 | XYZ
+(3 rows)
+
+-- TG
+/* aggregate functions alias not support failed. (10)
+EXECUTE select_t2_group1_ng;
+*/
+EXECUTE select_t2_group1;
+ count | sum | c7  
+-------+-----+-----
+     1 |     | 
+     2 |  44 | ABC
+     2 |  77 | XYZ
+(3 rows)
+
+-- GROUP BY #2
+-- PG
+EXECUTE select_pt2_group2;
+ count(c1) | sum(c2) | c7  
+-----------+---------+-----
+         2 |      77 | XYZ
+(1 row)
+
+-- TG
+/* aggregate functions alias not support failed. (10)
+EXECUTE select_t2_group2_ng1;
+*/
+/* having not support failed. (10)
+EXECUTE select_t2_group2_ng2;
+*/
+-- GROUP BY #3
+-- PG
+EXECUTE select_pt2_group3;
+ c7  | count | sum |         avg          | min | max  
+-----+-------+-----+----------------------+-----+------
+     |     1 |     |                      |     |     
+ ABC |     2 |  44 | 222.0000000000000000 | 1.1 | 3.33
+ XYZ |     2 |  77 | 388.5000000000000000 | 2.2 | 5.55
+(3 rows)
+
+-- TG
+/* not support avg return data type 1700: NUMERICOID
+EXECUTE select_t2_group3_exe_ng1;
+*/
+-- FOREIGN TABLE JOIN
+-- TG JOIN #1
+EXECUTE select_join1;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             | c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+----------------------------+----+----+-----+-----+------+------------+-----
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+(2 rows)
+
+-- TG JOIN #2
+/* failed (10) : mismatched input 'USING'
+EXECUTE select_join2;
+*/
+-- TG JOIN #3
+EXECUTE select_join3;
+ c1 | c3  | c1 |     c6     
+----+-----+----+------------
+  1 | 111 |  2 | two       
+  1 | 111 |  3 | three     
+  1 | 111 |  4 | NULL      
+  1 | 111 |  5 | five      
+  2 | 222 |  1 | one       
+  2 | 222 |  3 | three     
+  2 | 222 |  4 | NULL      
+  2 | 222 |  5 | five      
+  3 | 333 |  1 | one       
+  3 | 333 |  2 | two       
+  3 | 333 |  4 | NULL      
+  3 | 333 |  5 | five      
+(12 rows)
+
+-- POSTGRESQL TABLE JOIN
+-- PG JOIN #1
+-- PG
+EXECUTE select_pg_join_pg1;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             | c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+----------------------------+----+----+-----+-----+------+------------+-----
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+(2 rows)
+
+-- TG
+/* tables are mixed */
+EXECUTE select_pg_join_tg1;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             | c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+----------------------------+----+----+-----+-----+------+------------+-----
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+(2 rows)
+
+-- PG JOIN #2
+-- PG
+EXECUTE select_pg_join_pg2;
+ c1 | c2 | c4  |     c6     
+----+----+-----+------------
+  3 | 33 | 3.3 | three     
+  2 | 22 | 2.2 | two       
+  1 | 11 | 1.1 | one       
+(3 rows)
+
+-- TG
+/* tables are mixed */
+EXECUTE select_pg_join_tg2;
+ c1 | c2 | c4  |     c6     
+----+----+-----+------------
+  3 | 33 | 3.3 | three     
+  2 | 22 | 2.2 | two       
+  1 | 11 | 1.1 | one       
+(3 rows)
+
+-- PG JOIN  #3
+-- PG
+EXECUTE select_pg_join_pg3;
+ c1 | c3  |  c5  |             c7             
+----+-----+------+----------------------------
+  1 | 111 | 1.11 | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  2 | 222 | 2.22 | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  3 | 333 | 3.33 | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  4 |     |      | 
+  5 | 555 |      | 
+(5 rows)
+
+-- TG
+/* tables are mixed */
+EXECUTE select_pg_join_tg3;
+ c1 | c3  |  c5  |             c7             
+----+-----+------+----------------------------
+  1 | 111 | 1.11 | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  2 | 222 | 2.22 | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  3 | 333 | 3.33 | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  4 |     |      | 
+  5 | 555 |      | 
+(5 rows)
+
+-- PG JOIN #4
+-- PG
+EXECUTE select_pg_join_pg4;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             | c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+----------------------------+----+----+-----+-----+------+------------+-----
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+(1 row)
+
+-- TG
+/* tables are mixed */
+EXECUTE select_pg_join_tg4;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             | c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+----------------------------+----+----+-----+-----+------+------------+-----
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+(1 row)
+
+-- PG JOIN #5
+-- PG
+EXECUTE select_pg_join_pg5;
+ count | sum | c7  
+-------+-----+-----
+     2 |  44 | ABC
+     1 |  22 | XYZ
+(2 rows)
+
+-- TG
+/* tables are mixed */
+EXECUTE select_pg_join_tg5;
+ count | sum | c7  
+-------+-----+-----
+     2 |  44 | ABC
+     1 |  22 | XYZ
+(2 rows)
+
+-- PG JOIN #6
+-- PG
+EXECUTE select_pg_join_pg6;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             | c1 | c2 | c3  | c4  |  c5  |     c6     | c7  | c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             
+----+----+-----+-----+------+------------+----------------------------+----+----+-----+-----+------+------------+-----+----+----+-----+-----+------+------------+----------------------------
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ |  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(1 row)
+
+-- TG
+EXECUTE select_pg_join_tg6;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             | c1 | c2 | c3  | c4  |  c5  |     c6     | c7  | c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             
+----+----+-----+-----+------+------------+----------------------------+----+----+-----+-----+------+------------+-----+----+----+-----+-----+------+------------+----------------------------
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ |  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(1 row)
+
+-- PG&TG
+/* tables are mixed */
+EXECUTE select_pg_join_pgtg6;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             | c1 | c2 | c3  | c4  |  c5  |     c6     | c7  | c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             
+----+----+-----+-----+------+------------+----------------------------+----+----+-----+-----+------+------------+-----+----+----+-----+-----+------+------------+----------------------------
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ |  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(1 row)
+
+-- PG JOIN #7
+-- PG
+EXECUTE select_pg_join_pg7;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             | c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+----------------------------+----+----+-----+-----+------+------------+-----
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  4 |    |     |     |      | NULL       | 
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  4 |    |     |     |      | NULL       | 
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  4 |    |     |     |      | NULL       | 
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+(15 rows)
+
+-- TG
+EXECUTE select_pg_join_tg7;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             | c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+----------------------------+----+----+-----+-----+------+------------+-----
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  4 |    |     |     |      | NULL       | 
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  4 |    |     |     |      | NULL       | 
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  4 |    |     |     |      | NULL       | 
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+(15 rows)
+
+-- PG&TG
+/* tables are mixed */
+EXECUTE select_pg_join_pgtg7;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             | c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+----------------------------+----+----+-----+-----+------+------------+-----
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  4 |    |     |     |      | NULL       | 
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  4 |    |     |     |      | NULL       | 
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  4 |    |     |     |      | NULL       | 
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+(15 rows)
+
+-- PG JOIN #8
+-- PG
+EXECUTE select_pg_join_pg8;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             | c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             
+----+----+-----+-----+------+------------+----------------------------+----+----+-----+-----+------+------------+----------------------------
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(3 rows)
+
+-- TG
+EXECUTE select_pg_join_tg8;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             | c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             
+----+----+-----+-----+------+------------+----------------------------+----+----+-----+-----+------+------------+----------------------------
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(3 rows)
+
+/***********/
+/*** DDL ***/
+/***********/
+DROP TABLE t1;
+DROP FOREIGN TABLE t1;
+DROP TABLE t2;
+DROP FOREIGN TABLE t2;
+DROP TABLE t3;
+DROP FOREIGN TABLE t3;
+DROP TABLE pt1;
+DROP TABLE pt2;
+DROP TABLE pt3;

--- a/expected/prepare_statment.out
+++ b/expected/prepare_statment.out
@@ -1,0 +1,260 @@
+/* SET DATASTYLE */
+SET datestyle TO ISO, ymd;
+/* preparation */
+-- table preparation
+CREATE TABLE trg_table (id INTEGER NOT NULL PRIMARY KEY, num INTEGER, name VARCHAR(10)) TABLESPACE tsurugi;
+CREATE FOREIGN TABLE trg_table (id INTEGER NOT NULL, num INTEGER, name VARCHAR(10)) SERVER ogawayama;
+CREATE TABLE trg_timedate (
+    id      INTEGER NOT NULL PRIMARY KEY,
+    col1    TIMESTAMP  default '2023-03-03 23:59:35.123456',
+    col2    DATE       default '1999-01-08',
+    col3    TIME       default '04:05:06.789012345',
+    col4    TIME       default '040506',
+    col5    TIME       default '04:05 AM'
+) TABLESPACE tsurugi;
+CREATE FOREIGN TABLE trg_timedate (
+    id      INTEGER NOT NULL,
+    col1    TIMESTAMP  default '2023-03-03 23:59:35.123456',
+    col2    DATE       default '1999-01-08',
+    col3    TIME       default '04:05:06.789012345',
+    col4    TIME       default '040506',
+    col5    TIME       default '04:05 AM'
+) SERVER ogawayama;
+PREPARE add_trg_table (int, int, varchar(80)) 		AS INSERT INTO trg_table (id, num, name) VALUES ($1, $2, $3);
+PREPARE add_trg_table_num (int, int) 				AS INSERT INTO trg_table (id, num, name) VALUES ($1, $2, 'zzz');
+PREPARE add_trg_table_name (int, varchar(80))		AS INSERT INTO trg_table (id, num, name) VALUES ($1, 99, $2);
+PREPARE chg_trg_table_name (int, varchar(80)) 		AS UPDATE trg_table SET name = $2 WHERE id = $1;
+PREPARE chg_trg_table_num (int, int)         		AS UPDATE trg_table SET num  = $2 WHERE id = $1;
+PREPARE chg_trg_table_88_name (int, varchar(80))	AS UPDATE trg_table SET num  = 88, name = $2 WHERE id = $1;
+PREPARE chg_trg_table_num_yyy (int, int)    		AS UPDATE trg_table SET num  = $2, name = 'yyy' WHERE id = $1;
+PREPARE all_chg_trg_table_name (varchar(80))      	AS UPDATE trg_table SET name = $1;
+PREPARE all_chg_trg_table_num (int)      			AS UPDATE trg_table SET num = $1;
+PREPARE del_trg_table_num  (int)              		AS DELETE FROM trg_table WHERE num = $1;
+PREPARE del_trg_table_name (varchar(80))      		AS DELETE FROM trg_table WHERE name = $1;
+PREPARE all_select_table							AS SELECT * FROM trg_table;
+PREPARE all_select_table_num (int)					AS SELECT * FROM trg_table WHERE num > $1;
+PREPARE all_select_table_num2 (int, int)			AS SELECT * FROM trg_table WHERE num > $1 AND num < $2;
+PREPARE all_select_table_name (varchar(80))			AS SELECT * FROM trg_table WHERE name = $1;
+select * from trg_table;
+ id | num | name 
+----+-----+------
+(0 rows)
+
+EXECUTE add_trg_table (1, 11, 'aaa');
+select * from trg_table;
+ id | num | name 
+----+-----+------
+  1 |  11 | aaa
+(1 row)
+
+EXECUTE add_trg_table (2, 22, 'bbb');
+select * from trg_table;
+ id | num | name 
+----+-----+------
+  1 |  11 | aaa
+  2 |  22 | bbb
+(2 rows)
+
+EXECUTE add_trg_table (3, 33, 'ccc');
+select * from trg_table;
+ id | num | name 
+----+-----+------
+  1 |  11 | aaa
+  2 |  22 | bbb
+  3 |  33 | ccc
+(3 rows)
+
+EXECUTE add_trg_table (4, 44, 'ddd');
+select * from trg_table;
+ id | num | name 
+----+-----+------
+  1 |  11 | aaa
+  2 |  22 | bbb
+  3 |  33 | ccc
+  4 |  44 | ddd
+(4 rows)
+
+EXECUTE add_trg_table_num (5, 55);
+select * from trg_table;
+ id | num | name 
+----+-----+------
+  1 |  11 | aaa
+  2 |  22 | bbb
+  3 |  33 | ccc
+  4 |  44 | ddd
+  5 |  55 | zzz
+(5 rows)
+
+EXECUTE add_trg_table_name (6, 'fff');
+select * from trg_table;
+ id | num | name 
+----+-----+------
+  1 |  11 | aaa
+  2 |  22 | bbb
+  3 |  33 | ccc
+  4 |  44 | ddd
+  5 |  55 | zzz
+  6 |  99 | fff
+(6 rows)
+
+EXECUTE all_select_table;
+ id | num | name 
+----+-----+------
+  1 |  11 | aaa
+  2 |  22 | bbb
+  3 |  33 | ccc
+  4 |  44 | ddd
+  5 |  55 | zzz
+  6 |  99 | fff
+(6 rows)
+
+select * from trg_table where num > 30;
+ id | num | name 
+----+-----+------
+  3 |  33 | ccc
+  4 |  44 | ddd
+  5 |  55 | zzz
+  6 |  99 | fff
+(4 rows)
+
+EXECUTE all_select_table_num(30);
+ id | num | name 
+----+-----+------
+  3 |  33 | ccc
+  4 |  44 | ddd
+  5 |  55 | zzz
+  6 |  99 | fff
+(4 rows)
+
+select * from trg_table where num > 20 and num < 50;
+ id | num | name 
+----+-----+------
+  2 |  22 | bbb
+  3 |  33 | ccc
+  4 |  44 | ddd
+(3 rows)
+
+EXECUTE all_select_table_num2(20, 50);
+ id | num | name 
+----+-----+------
+  2 |  22 | bbb
+  3 |  33 | ccc
+  4 |  44 | ddd
+(3 rows)
+
+select * from trg_table where name = 'fff';
+ id | num | name 
+----+-----+------
+  6 |  99 | fff
+(1 row)
+
+EXECUTE all_select_table_name('fff');
+ id | num | name 
+----+-----+------
+  6 |  99 | fff
+(1 row)
+
+EXECUTE chg_trg_table_name (1, 'xyz');
+select * from trg_table;
+ id | num | name 
+----+-----+------
+  1 |  11 | xyz
+  2 |  22 | bbb
+  3 |  33 | ccc
+  4 |  44 | ddd
+  5 |  55 | zzz
+  6 |  99 | fff
+(6 rows)
+
+EXECUTE chg_trg_table_num (2, 789);
+select * from trg_table;
+ id | num | name 
+----+-----+------
+  1 |  11 | xyz
+  2 | 789 | bbb
+  3 |  33 | ccc
+  4 |  44 | ddd
+  5 |  55 | zzz
+  6 |  99 | fff
+(6 rows)
+
+EXECUTE chg_trg_table_88_name (3, 'xyz');
+select * from trg_table;
+ id | num | name 
+----+-----+------
+  1 |  11 | xyz
+  2 | 789 | bbb
+  3 |  88 | xyz
+  4 |  44 | ddd
+  5 |  55 | zzz
+  6 |  99 | fff
+(6 rows)
+
+EXECUTE chg_trg_table_88_name (4, 'xyz');
+select * from trg_table;
+ id | num | name 
+----+-----+------
+  1 |  11 | xyz
+  2 | 789 | bbb
+  3 |  88 | xyz
+  4 |  88 | xyz
+  5 |  55 | zzz
+  6 |  99 | fff
+(6 rows)
+
+EXECUTE del_trg_table_num  (789);
+select * from trg_table;
+ id | num | name 
+----+-----+------
+  1 |  11 | xyz
+  3 |  88 | xyz
+  4 |  88 | xyz
+  5 |  55 | zzz
+  6 |  99 | fff
+(5 rows)
+
+EXECUTE del_trg_table_name ('xyz');
+select * from trg_table;
+ id | num | name 
+----+-----+------
+  5 |  55 | zzz
+  6 |  99 | fff
+(2 rows)
+
+EXECUTE all_chg_trg_table_name ('abc');
+select * from trg_table;
+ id | num | name 
+----+-----+------
+  5 |  55 | abc
+  6 |  99 | abc
+(2 rows)
+
+EXECUTE all_chg_trg_table_num (123);
+select * from trg_table;
+ id | num | name 
+----+-----+------
+  5 | 123 | abc
+  6 | 123 | abc
+(2 rows)
+
+PREPARE add_trg_timedate (int)   AS INSERT INTO trg_timedate (id) VALUES ($1);
+EXECUTE add_trg_timedate (1);
+EXECUTE add_trg_timedate (2);
+EXECUTE add_trg_timedate (3);
+EXECUTE add_trg_timedate (4);
+EXECUTE add_trg_timedate (5);
+select * from trg_timedate;
+ id |            col1            |    col2    |      col3       |   col4   |   col5   
+----+----------------------------+------------+-----------------+----------+----------
+  1 | 2023-03-03 23:59:35.123456 | 1999-01-08 | 04:05:06.789012 | 04:05:06 | 04:05:00
+  2 | 2023-03-03 23:59:35.123456 | 1999-01-08 | 04:05:06.789012 | 04:05:06 | 04:05:00
+  3 | 2023-03-03 23:59:35.123456 | 1999-01-08 | 04:05:06.789012 | 04:05:06 | 04:05:00
+  4 | 2023-03-03 23:59:35.123456 | 1999-01-08 | 04:05:06.789012 | 04:05:06 | 04:05:00
+  5 | 2023-03-03 23:59:35.123456 | 1999-01-08 | 04:05:06.789012 | 04:05:06 | 04:05:00
+(5 rows)
+
+/* clean up */
+DROP FOREIGN TABLE trg_timedate;
+DROP TABLE trg_timedate;
+DROP FOREIGN TABLE trg_table;
+DROP TABLE trg_table;

--- a/ogawayama_fdw/tsurugi_prepare.cpp
+++ b/ogawayama_fdw/tsurugi_prepare.cpp
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2023 tsurugi project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *	@file	tsurugi_prepare.cpp
+ *	@brief 	Dispatch the prepare statement to ogawayama.
+ */
+
+#include <map>
+
+#include "ogawayama/stub/api.h"
+#include "stub_manager.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "postgres.h"
+
+#include "catalog/pg_type.h"
+#include "nodes/params.h"
+#include "nodes/execnodes.h"
+
+extern void getTypeOutputInfo(Oid type, Oid *typOutput, bool *typIsVarlena);
+#ifdef __cplusplus
+}
+#endif
+
+#include "tsurugi_prepare.h"
+
+using namespace ogawayama;
+
+static constexpr const char* const PREPARE_NAME = "tsurugi_prep_";
+static constexpr const char* const PREPARE_PARAM_NAME = "param_";
+static constexpr const char* const PREPARE_PARAM_NAME_SQL = ":param_";
+
+// Name of the stored Prepared Statement.
+std::map<std::string, std::string> stored_prepare_name;
+int tsurugi_prep_number = 0;
+
+// Data Required for Prepared SQL Execution.
+extern PreparedStatementPtr prepared_statement;
+// Parameter Settings Required for Prepared SQL Execution.
+extern stub::parameters_type parameters;
+
+// Data Required for stored Prepared SQL Execution.
+extern std::map<std::string, PreparedStatementPtr> stored_prepare_statment;
+
+/**
+ *  @brief Begin processing of PreparedStatement via JDBC.
+ *  @param [in] working state for an Executor invocation
+ */
+void
+begin_prepare_processing(const EState* estate)
+{
+	ParamListInfo params = estate->es_param_list_info;
+
+	if (params == NULL) {
+		// If there is no parameter information, do nothing.
+		return;
+	}
+
+	if (parameters.size() != 0) {
+		// If there is an EXECUTE command, do nothing.
+		return;
+	}
+
+	std::string sql = estate->es_sourceText;
+
+	// Determine Tsurugi::prepare execution from stored prepared statement name.
+	std::map<std::string, std::string>::iterator itr = stored_prepare_name.find(sql);
+	if (itr == stored_prepare_name.end()) {
+		// Generating Prepared Statement Name.
+		std::string prepare_name = PREPARE_NAME + std::to_string(tsurugi_prep_number++);
+		stored_prepare_name[sql] = prepare_name;
+
+		// Generating (converting parameters) SQL text for Tsurugi Prepared Statements.
+		for (int i = 0; i < params->numParams; i++) {
+			std::string serch_param = "$" + std::to_string(i+1);
+			std::size_t serch_param_len = serch_param.length();
+			std::size_t param_pos = sql.find(serch_param);
+			if (param_pos == std::string::npos) {
+				elog(ERROR, "Unrecognized parameter position in SQL text.");
+				return;
+			}
+			std::string param_name = PREPARE_PARAM_NAME_SQL + std::to_string(i);
+			sql = sql.replace(param_pos, serch_param_len, param_name);
+		}
+
+		// Generating placeholders for Tsurugi Prepared Statements.
+		stub::placeholders_type placeholders{};
+		for (int i = 0; i < params->numParams; i++) {
+			std::string param_name = PREPARE_PARAM_NAME + std::to_string(i);
+			ParamExternData param = params->params[i];
+			switch (param.ptype)
+			{
+				case INT2OID:
+					placeholders.emplace_back(param_name,
+									stub::Metadata::ColumnType::Type::INT16);
+					break;
+				case INT4OID:
+					placeholders.emplace_back(param_name,
+									stub::Metadata::ColumnType::Type::INT32);
+					break;
+				case INT8OID:
+					placeholders.emplace_back(param_name,
+									stub::Metadata::ColumnType::Type::INT64);
+					break;
+				case FLOAT4OID:
+					placeholders.emplace_back(param_name,
+									stub::Metadata::ColumnType::Type::FLOAT32);
+					break;
+				case FLOAT8OID:
+					placeholders.emplace_back(param_name,
+									stub::Metadata::ColumnType::Type::FLOAT64);
+					break;
+				case BPCHAROID:
+				case VARCHAROID:
+				case TEXTOID:
+					placeholders.emplace_back(param_name,
+									stub::Metadata::ColumnType::Type::TEXT);
+					break;
+				case DATEOID:
+					placeholders.emplace_back(param_name,
+									stub::Metadata::ColumnType::Type::DATE);
+					break;
+				case TIMEOID:
+					placeholders.emplace_back(param_name,
+									stub::Metadata::ColumnType::Type::TIME);
+					break;
+				case TIMESTAMPOID:
+					placeholders.emplace_back(param_name,
+									stub::Metadata::ColumnType::Type::TIMESTAMP);
+					break;
+				case TIMETZOID:
+					placeholders.emplace_back(param_name,
+									stub::Metadata::ColumnType::Type::TIMETZ);
+					break;
+				case TIMESTAMPTZOID:
+					placeholders.emplace_back(param_name,
+									stub::Metadata::ColumnType::Type::TIMESTAMPTZ);
+					break;
+				case NUMERICOID:
+					placeholders.emplace_back(param_name,
+									stub::Metadata::ColumnType::Type::DECIMAL);
+					break;
+				default:
+					elog(ERROR, "unrecognized type oid: %d", (int) param.ptype);
+					return;
+			}
+		}
+
+#if 1
+		stub::Connection* connection;
+		ERROR_CODE error = StubManager::get_connection(&connection);
+		if (error != ERROR_CODE::OK)
+		{
+			elog(ERROR, "StubManager::get_connection() failed. (code: %d)", (int) error);
+			return;
+		}
+		error = connection->prepare(sql, placeholders, prepared_statement);
+		if (error != ERROR_CODE::OK)
+		{
+			elog(ERROR, "connection->prepare() failed. (%d)\n\tsql:%s", (int) error, sql.c_str());
+			return;
+		}
+#else
+		ERROR_CODE error = Tsurugi::prepare(sql, placeholders, prepared_statement);
+		if (error != ERROR_CODE::OK)
+		{
+			elog(ERROR, "Tsurugi::prepare() failed. (%d)\n\tsql:%s", (int) error, sql.c_str());
+			return;
+		}
+#endif
+	} else {
+		// Restore the Data Required for Prepared SQL Execution.
+		std::string prepare_name = stored_prepare_name[sql];
+		prepared_statement = std::move(stored_prepare_statment.at(prepare_name));
+	}
+
+	// Generating parameters for Tsurugi Prepared Statements.
+	for (int i = 0; i < params->numParams; i++) {
+		std::string param_name = PREPARE_PARAM_NAME + std::to_string(i);
+		ParamExternData param = params->params[i];
+		switch (param.ptype)
+		{
+			case INT2OID:
+				parameters.emplace_back(param_name,
+								static_cast<std::int16_t>(DatumGetInt16(param.value)));
+				break;
+			case INT4OID:
+				parameters.emplace_back(param_name,
+								static_cast<std::int32_t>(DatumGetInt32(param.value)));
+				break;
+			case INT8OID:
+				parameters.emplace_back(param_name,
+								static_cast<std::int64_t>(DatumGetInt64(param.value)));
+				break;
+			case FLOAT4OID:
+				parameters.emplace_back(param_name,
+								static_cast<float>(DatumGetFloat4(param.value)));
+				break;
+			case FLOAT8OID:
+				parameters.emplace_back(param_name,
+								static_cast<double>(DatumGetFloat8(param.value)));
+				break;
+			case BPCHAROID:
+			case VARCHAROID:
+			case TEXTOID:
+				Oid typoutput;
+				bool typisvarlena;
+				char* pstring;
+				getTypeOutputInfo(param.ptype, &typoutput, &typisvarlena);
+				pstring = OidOutputFunctionCall(typoutput, param.value);
+				parameters.emplace_back(param_name, pstring);
+				pfree(pstring);
+				break;
+			default:
+				elog(ERROR, "unrecognized type oid: %d", (int) param.ptype);
+				return;
+		}
+	}
+}
+
+/**
+ *  @brief End processing of PreparedStatement via JDBC.
+ *  @param [in] working state for an Executor invocation
+ */
+void
+end_prepare_processing(const EState* estate)
+{
+	ParamListInfo params = estate->es_param_list_info;
+
+	if (params == NULL) {
+		// If there is no parameter information, do nothing.
+		return;
+	}
+
+	std::string sql = estate->es_sourceText;
+
+	std::map<std::string, std::string>::iterator itr = stored_prepare_name.find(sql);
+	if (itr != stored_prepare_name.end()) {
+		// Store the Data Required for Prepared SQL Execution.
+		std::string prepare_name = stored_prepare_name[sql];
+		stored_prepare_statment[prepare_name] = std::move(prepared_statement);
+		parameters = {};
+	} 
+}

--- a/ogawayama_fdw/tsurugi_prepare.h
+++ b/ogawayama_fdw/tsurugi_prepare.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 tsurugi project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *	@file	tsurugi_prepare.h
+ *	@brief 	Dispatch the prepare statement to ogawayama.
+ */
+#ifndef TSURUGI_PREPARE_H
+#define TSURUGI_PREPARE_H
+
+void begin_prepare_processing(const EState* estate);
+void end_prepare_processing(const EState* estate);
+
+#endif  //TSURUGI_PREPARE_H

--- a/sql/prepare_select_statment.sql
+++ b/sql/prepare_select_statment.sql
@@ -1,0 +1,581 @@
+/***********/
+/*** DDL ***/
+/***********/
+-- TG tables
+CREATE TABLE t1(
+    c1 INTEGER PRIMARY KEY, 
+    c2 INTEGER, 
+    c3 BIGINT,
+    c4 REAL, 
+    c5 DOUBLE PRECISION, 
+    c6 CHAR(10),
+    c7 VARCHAR(26)
+) TABLESPACE tsurugi;
+
+CREATE FOREIGN TABLE t1(
+    c1 INTEGER, 
+    c2 INTEGER, 
+    c3 BIGINT,
+    c4 REAL, 
+    c5 DOUBLE PRECISION, 
+    c6 CHAR(10),
+    c7 VARCHAR(26)
+) SERVER ogawayama;
+
+CREATE TABLE t2(
+    c1 INTEGER PRIMARY KEY, 
+    c2 INTEGER, 
+    c3 BIGINT,
+    c4 REAL, 
+    c5 DOUBLE PRECISION, 
+    c6 CHAR(10),
+    c7 VARCHAR(26)
+) TABLESPACE tsurugi;
+
+CREATE FOREIGN TABLE t2(
+    c1 INTEGER, 
+    c2 INTEGER, 
+    c3 BIGINT,
+    c4 REAL, 
+    c5 DOUBLE PRECISION, 
+    c6 CHAR(10),
+    c7 VARCHAR(26)
+) SERVER ogawayama;
+
+CREATE TABLE t3(
+    c1 INTEGER PRIMARY KEY,
+    c2 CHAR(10)
+) TABLESPACE tsurugi;
+
+CREATE FOREIGN TABLE t3(
+    c1 INTEGER,
+    c2 CHAR(10)
+) SERVER ogawayama;
+
+-- PG tables
+CREATE TABLE pt1(
+    c1 INTEGER PRIMARY KEY, 
+    c2 INTEGER, 
+    c3 BIGINT,
+    c4 REAL, 
+    c5 DOUBLE PRECISION, 
+    c6 CHAR(10),
+    c7 VARCHAR(26)
+);
+
+CREATE TABLE pt2(
+    c1 INTEGER PRIMARY KEY, 
+    c2 INTEGER, 
+    c3 BIGINT,
+    c4 REAL, 
+    c5 DOUBLE PRECISION, 
+    c6 CHAR(10),
+    c7 VARCHAR(26)
+);
+
+CREATE TABLE pt3(
+    c1 INTEGER PRIMARY KEY,
+    c2 CHAR(10)
+);
+
+/***************/
+/*** PREPARE ***/
+/***************/
+-- TG tables
+PREPARE insert_t1 (INTEGER, INTEGER, BIGINT, REAL, DOUBLE PRECISION, CHAR(10), VARCHAR(26)) 
+    AS INSERT INTO t1 (c1, c2, c3, c4, c5, c6, c7) VALUES ($1, $2, $3, $4, $5, $6, $7);
+PREPARE select_t1_all 
+	AS SELECT * FROM t1;
+PREPARE insert_t2 (INTEGER, INTEGER, BIGINT, REAL, DOUBLE PRECISION, CHAR(10), VARCHAR(26)) 
+    AS INSERT INTO t2 (c1, c2, c3, c4, c5, c6, c7) VALUES ($1, $2, $3, $4, $5, $6, $7);
+PREPARE select_t2_all 
+	AS SELECT * FROM t2;
+PREPARE insert_t3 (INTEGER, CHAR(10)) 
+    AS INSERT INTO t3 (c1, c2) VALUES ($1, $2);
+PREPARE select_t3_all 
+	AS SELECT * FROM t3;
+
+-- PG tables
+PREPARE insert_pt1 (INTEGER, INTEGER, BIGINT, REAL, DOUBLE PRECISION, CHAR(10), VARCHAR(26)) 
+    AS INSERT INTO pt1 (c1, c2, c3, c4, c5, c6, c7) VALUES ($1, $2, $3, $4, $5, $6, $7);
+PREPARE select_pt1_all 
+	AS SELECT * FROM pt1;
+PREPARE insert_pt2 (INTEGER, INTEGER, BIGINT, REAL, DOUBLE PRECISION, CHAR(10), VARCHAR(26)) 
+    AS INSERT INTO pt2 (c1, c2, c3, c4, c5, c6, c7) VALUES ($1, $2, $3, $4, $5, $6, $7);
+PREPARE select_pt2_all 
+	AS SELECT * FROM pt2;
+PREPARE insert_pt3 (INTEGER, CHAR(10)) 
+    AS INSERT INTO pt3 (c1, c2) VALUES ($1, $2);
+PREPARE select_pt3_all 
+	AS SELECT * FROM pt3;
+
+-- SELECT
+-- PG
+PREPARE select_pt2_c2_c4_c6
+	AS SELECT c2, c4, c6 FROM pt2;
+-- TG
+PREPARE select_t2_c2_c4_c6
+	AS SELECT c2, c4, c6 FROM t2;
+-- PG
+PREPARE select_pt2_c6
+	AS SELECT c6 FROM pt2;
+-- TG
+PREPARE select_t2_c6
+	AS SELECT c6 FROM t2;
+-- PG
+PREPARE select_pt2_c1_c2_seisu
+	AS SELECT c1, c2 AS seisu FROM pt2;
+-- TG
+PREPARE select_t2_c1_c2_seisu
+	AS SELECT c1, c2 AS seisu FROM t2;
+
+-- ORDER BY #1
+-- PG
+PREPARE select_pt2_orderby1
+	AS SELECT * FROM pt2 ORDER BY c6;
+-- TG
+PREPARE select_t2_orderby1
+	AS SELECT * FROM t2 ORDER BY c6;
+-- ORDER BY #2
+-- PG
+PREPARE select_pt2_orderby2
+	AS SELECT c1, c2, c3, c4, c5, c6, c7 FROM pt2 ORDER BY 6;
+-- TG
+/* failed (10) because of ORDER BY 6 */
+PREPARE select_t2_orderby2
+	AS SELECT c1, c2, c3, c4, c5, c6, c7 FROM t2 ORDER BY 6;
+-- ORDER BY #3
+-- PG
+PREPARE select_pt2_orderby3
+	AS SELECT c1, c4, c5, c6, c7 FROM pt2 WHERE c1 > 2 ORDER BY c7;
+-- TG
+PREPARE select_t2_orderby3
+	AS SELECT c1, c4, c5, c6, c7 FROM t2 WHERE c1 > 2 ORDER BY c7;
+-- ORDER BY #4
+-- PG
+PREPARE select_pt2_orderby4
+	AS SELECT c1, c2 FROM pt2 WHERE c2 * 2 > 50 ORDER BY c3 DESC;
+-- TG
+PREPARE select_t2_orderby4
+	AS SELECT c1, c2 FROM t2 WHERE c2 * 2 > 50 ORDER BY c3 DESC;
+
+-- WHERE #1
+-- PG
+PREPARE select_pt2_where1
+	AS SELECT * FROM pt2 WHERE c3 > 2 ORDER BY c1;
+-- TG
+PREPARE select_t2_where1
+	AS SELECT * FROM t2 WHERE c3 > 2 ORDER BY c1;
+-- WHERE #2
+-- PG
+PREPARE select_pt2_where2
+	AS SELECT * FROM pt2 WHERE c7 = 'XYZ' ORDER BY c1;
+-- TG
+PREPARE select_t2_where2
+	AS SELECT * FROM t2 WHERE c7 = 'XYZ' ORDER BY c1;
+-- WHERE #3
+-- PG
+PREPARE select_pt1_where3
+	AS SELECT c1, c2, c6, c7 FROM pt1 WHERE c1 = 1 OR c1 = 3;
+-- TG
+PREPARE select_t1_where3
+	AS SELECT c1, c2, c6, c7 FROM t1 WHERE c1 = 1 OR c1 = 3;
+-- WHERE #4
+-- PG
+PREPARE select_pt1_where4
+	AS SELECT c1, c3, c5, c7 FROM pt1 WHERE c1 = 2;
+-- TG
+PREPARE select_t1_where4
+	AS SELECT c1, c3, c5, c7 FROM t1 WHERE c1 = 2;
+-- WHERE #5
+-- PG
+PREPARE select_pt1_where5
+	AS SELECT * FROM pt1 WHERE c4 >= 2.2 AND c4 < 5.5;
+-- TG
+PREPARE select_t1_where5
+	AS SELECT * FROM t1 WHERE c4 >= 2.2 AND c4 < 5.5;
+-- WHERE #6
+-- PG
+PREPARE select_pt2_where6
+	AS SELECT * FROM pt2 WHERE c4 BETWEEN 2.2 AND 5.5;
+-- TG
+/* tsurugi-issue#69 */
+PREPARE select_t2_where6
+	AS SELECT * FROM t2 WHERE c4 BETWEEN 2.2 AND 5.5;
+-- WHERE #7
+-- PG
+PREPARE select_pt1_where7
+	AS SELECT * FROM pt1 WHERE c7 LIKE '%LMN%';
+-- TG
+/* tsurugi-issue#103 */
+PREPARE select_t1_where7
+	AS SELECT * FROM t1 WHERE c7 LIKE '%LMN%';
+-- WHERE #8
+-- PG
+PREPARE select_pt1_where8
+	AS SELECT * FROM pt1 WHERE EXISTS (SELECT * FROM pt2 WHERE c2 = 22);
+-- TG
+/* not support EXISTS failed. (10) */
+PREPARE select_t1_where8
+	AS SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t2 WHERE c2 = 22);
+-- WHERE #9
+-- PG
+PREPARE select_pt2_where9
+	AS SELECT * FROM pt2 WHERE c4 IN (1.1,3.3);
+-- TG
+/* tsurugi-issue#70 */
+PREPARE select_t2_where9
+	AS SELECT * FROM t2 WHERE c4 IN (1.1,3.3);
+
+-- GROUP BY #1
+-- PG
+PREPARE select_pt2_group1
+	AS SELECT count(c1) AS "count(c1)", sum(c2) AS "sum(c2)", c7 FROM pt2 GROUP BY c7;
+-- TG
+/* aggregate functions alias not support failed. (10) */
+PREPARE select_t2_group1_ng
+	AS SELECT count(c1) AS "count(c1)", sum(c2) AS "sum(c2)", c7 FROM t2 GROUP BY c7;
+PREPARE select_t2_group1
+	AS SELECT count(c1), sum(c2), c7 FROM t2 GROUP BY c7;
+-- GROUP BY #2
+-- PG
+PREPARE select_pt2_group2
+	AS SELECT count(c1) AS "count(c1)", sum(c2) AS "sum(c2)", c7 FROM pt2 GROUP BY c7 HAVING sum(c2) > 55;
+-- TG
+/* aggregate functions alias not support failed. (10) */
+PREPARE select_t2_group2_ng1
+	AS SELECT count(c1) AS "count(c1)", sum(c2) AS "sum(c2)", c7 FROM t2 GROUP BY c7 HAVING sum(c2) > 55;
+/* having not support failed. (10) */
+PREPARE select_t2_group2_ng2
+	AS SELECT count(c1), sum(c2), c7 FROM t2 GROUP BY c7 HAVING sum(c2) > 55;
+-- GROUP BY #3
+-- PG
+PREPARE select_pt2_group3
+	AS SELECT c7, count(c1), sum(c2), avg(c3), min(c4), max(c5) FROM pt2 GROUP BY c7;
+-- TG
+PREPARE select_t2_group3_exe_ng1
+	AS SELECT c7, count(c1), sum(c2), avg(c3), min(c4), max(c5) FROM t2 GROUP BY c7;
+
+-- FOREIGN TABLE JOIN
+-- TG JOIN #1
+PREPARE select_join1
+	AS SELECT * FROM t1 a INNER JOIN t2 b ON a.c1 = b.c1 WHERE b.c1 > 1;
+-- TG JOIN #2
+/* failed (10) : mismatched input 'USING' */
+PREPARE select_join2
+	AS SELECT a.c1, a.c2, b.c1, b.c7 FROM t1 a INNER JOIN t2 b USING (c1) ORDER BY b.c4 DESC;
+-- TG JOIN #3
+PREPARE select_join3
+	AS SELECT a.c1, a.c3, b.c1, b.c6 FROM t1 a INNER JOIN t2 b ON a.c1 != b.c1;
+
+-- POSTGRESQL TABLE JOIN
+-- PG JOIN #1
+-- PG
+PREPARE select_pg_join_pg1
+	AS SELECT * FROM pt1 a INNER JOIN pt2 b ON a.c4 = b.c4 WHERE a.c1 > 1;
+-- TG
+/* tables are mixed */
+PREPARE select_pg_join_tg1
+	AS SELECT * FROM t1 a INNER JOIN pt2 b ON a.c4 = b.c4 WHERE a.c1 > 1;
+-- PG JOIN #2
+-- PG
+PREPARE select_pg_join_pg2
+	AS SELECT a.c1, a.c2, b.c4, b.c6 FROM pt1 a INNER JOIN pt2 b USING (c1) ORDER BY b.c4 DESC;
+-- TG
+/* tables are mixed */
+PREPARE select_pg_join_tg2
+	AS SELECT a.c1, a.c2, b.c4, b.c6 FROM t1 a INNER JOIN pt2  b USING (c1) ORDER BY b.c4 DESC;
+-- PG JOIN  #3
+-- PG
+PREPARE select_pg_join_pg3
+	AS SELECT a.c1, a.c3, b.c5, b.c7 FROM pt2 a LEFT OUTER JOIN pt1 b ON a.c1 = b.c1;
+-- TG
+/* tables are mixed */
+PREPARE select_pg_join_tg3
+	AS SELECT a.c1, a.c3, b.c5, b.c7 FROM t2 a LEFT OUTER JOIN pt1 b ON a.c1 = b.c1;
+-- PG JOIN #4
+-- PG
+PREPARE select_pg_join_pg4
+	AS SELECT * FROM pt1 a INNER JOIN pt2 b ON a.c4 = b.c4 WHERE a.c1 > 1 AND a.c1 < 3;
+-- TG
+/* tables are mixed */
+PREPARE select_pg_join_tg4
+	AS SELECT * FROM pt1 a INNER JOIN t2 b ON a.c4 = b.c4 WHERE a.c1 > 1 AND a.c1 < 3;
+-- PG JOIN #5
+-- PG
+PREPARE select_pg_join_pg5
+	AS SELECT count(a.c1), sum(b.c2), b.c7 FROM pt1 a INNER JOIN pt2 b USING (c2) GROUP BY b.c7;
+-- TG
+/* tables are mixed */
+PREPARE select_pg_join_tg5
+	AS SELECT count(a.c1), sum(b.c2), b.c7 FROM pt1 a INNER JOIN t2 b USING (c2) GROUP BY b.c7;
+-- PG JOIN #6
+-- PG
+PREPARE select_pg_join_pg6
+	AS SELECT * FROM pt1 AS a JOIN pt2 AS b ON a.c4=b.c4 JOIN pt1 AS c ON b.c4=c.c4 WHERE a.c2=22;
+-- TG
+PREPARE select_pg_join_tg6
+	AS SELECT * FROM t1 AS a JOIN t2 AS b ON a.c4=b.c4 JOIN t1 AS c ON b.c4=c.c4 WHERE a.c2=22;
+-- PG&TG
+/* tables are mixed */
+PREPARE select_pg_join_pgtg6
+	AS SELECT * FROM t1 AS a JOIN pt2 AS b ON a.c4=b.c4 JOIN t1 AS c ON b.c4=c.c4 WHERE a.c2=22;
+-- PG JOIN #7
+-- PG
+PREPARE select_pg_join_pg7
+	AS SELECT * FROM pt1 AS a CROSS JOIN pt2 AS b ORDER BY b.c1;
+-- TG
+PREPARE select_pg_join_tg7
+	AS SELECT * FROM t1 AS a CROSS JOIN t2 AS b ORDER BY b.c1;
+-- PG&TG
+/* tables are mixed */
+PREPARE select_pg_join_pgtg7
+	AS SELECT * FROM pt1 AS a CROSS JOIN t2 AS b ORDER BY b.c1;
+-- PG JOIN #8
+-- PG
+PREPARE select_pg_join_pg8
+	AS SELECT * FROM pt1 AS a JOIN pt1 AS b ON a.c3=b.c3;
+-- TG
+PREPARE select_pg_join_tg8
+	AS SELECT * FROM t1 AS a JOIN t1 AS b ON a.c3=b.c3;
+
+
+/***************/
+/*** EXECUTE ***/
+/***************/
+-- TG tables
+EXECUTE insert_t1 (1, 11, 111, 1.1, 1.11, 'first', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+EXECUTE insert_t1 (2, 22, 222, 2.2, 2.22, 'second', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+EXECUTE insert_t1 (3, 33, 333, 3.3, 3.33, 'third', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+EXECUTE select_t1_all;
+
+EXECUTE insert_t2 (1, 11, 111, 1.1, 1.11, 'one', 'ABC');
+EXECUTE insert_t2 (2, 22, 222, 2.2, 2.22, 'two', 'XYZ');
+EXECUTE insert_t2 (3, 33, 333, 3.3, 3.33, 'three', 'ABC');
+EXECUTE insert_t2 (4, NULL, NULL, NULL, NULL, 'NULL', NULL);
+EXECUTE insert_t2 (5, 55, 555, 5.5, 5.55, 'five', 'XYZ');
+EXECUTE select_t2_all;
+
+EXECUTE insert_t3 (1, 'ichi');
+EXECUTE insert_t3 (2, 'ni');
+EXECUTE insert_t3 (3, 'san');
+EXECUTE insert_t3 (4, 'si');
+EXECUTE insert_t3 (5, 'go');
+EXECUTE select_t3_all;
+
+-- PG tables
+EXECUTE insert_pt1 (1, 11, 111, 1.1, 1.11, 'first', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+EXECUTE insert_pt1 (2, 22, 222, 2.2, 2.22, 'second', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+EXECUTE insert_pt1 (3, 33, 333, 3.3, 3.33, 'third', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+EXECUTE select_pt1_all;
+
+EXECUTE insert_pt2 (1, 11, 111, 1.1, 1.11, 'one', 'ABC');
+EXECUTE insert_pt2 (2, 22, 222, 2.2, 2.22, 'two', 'XYZ');
+EXECUTE insert_pt2 (3, 33, 333, 3.3, 3.33, 'three', 'ABC');
+EXECUTE insert_pt2 (4, NULL, NULL, NULL, NULL, 'NULL', NULL);
+EXECUTE insert_pt2 (5, 55, 555, 5.5, 5.55, 'five', 'XYZ');
+EXECUTE select_pt2_all;
+
+EXECUTE insert_pt3 (1, 'ichi');
+EXECUTE insert_pt3 (2, 'ni');
+EXECUTE insert_pt3 (3, 'san');
+EXECUTE insert_pt3 (4, 'si');
+EXECUTE insert_pt3 (5, 'go');
+EXECUTE select_pt3_all;
+
+-- SELECT
+-- PG
+EXECUTE select_pt1_all;
+-- TG
+EXECUTE select_t1_all;
+-- PG
+EXECUTE select_pt2_c2_c4_c6;
+-- TG
+EXECUTE select_t2_c2_c4_c6;
+-- PG
+EXECUTE select_pt2_c6;
+-- TG
+EXECUTE select_t2_c6;
+-- PG
+EXECUTE select_pt2_c1_c2_seisu;
+-- TG
+EXECUTE select_t2_c1_c2_seisu;
+
+-- ORDER BY #1
+-- PG
+EXECUTE select_pt2_orderby1;
+-- TG
+EXECUTE select_t2_orderby1;
+-- ORDER BY #2
+-- PG
+EXECUTE select_pt2_orderby2;
+-- TG
+/* failed (10) because of ORDER BY 6
+EXECUTE select_t2_orderby2;
+*/
+-- ORDER BY #3
+-- PG
+EXECUTE select_pt2_orderby3;
+-- TG
+EXECUTE select_t2_orderby3;
+-- ORDER BY #4
+-- PG
+EXECUTE select_pt2_orderby4;
+-- TG
+EXECUTE select_t2_orderby4;
+
+-- WHERE #1
+-- WHERE #1
+-- PG
+EXECUTE select_pt2_where1;
+-- TG
+EXECUTE select_t2_where1;
+-- WHERE #2
+-- PG
+EXECUTE select_pt2_where2;
+-- TG
+EXECUTE select_t2_where2;
+-- WHERE #3
+-- PG
+EXECUTE select_pt1_where3;
+-- TG
+EXECUTE select_t1_where3;
+-- WHERE #4
+-- PG
+EXECUTE select_pt1_where4;
+-- TG
+EXECUTE select_t1_where4;
+-- WHERE #5
+-- PG
+EXECUTE select_pt1_where5;
+-- TG
+EXECUTE select_t1_where5;
+-- WHERE #6
+-- PG
+EXECUTE select_pt2_where6;
+-- TG
+/* tsurugi-issue#69
+EXECUTE select_t2_where6;
+*/
+-- WHERE #7
+-- PG
+EXECUTE select_pt1_where7;
+-- TG
+/* tsurugi-issue#103 */
+EXECUTE select_t1_where7;
+-- WHERE #8
+-- PG
+EXECUTE select_pt1_where8;
+-- TG
+/* not support EXISTS failed. (10)
+EXECUTE select_t1_where8;
+*/
+-- WHERE #9
+-- PG
+EXECUTE select_pt2_where9;
+-- TG
+/* tsurugi-issue#70
+EXECUTE select_t2_where9;
+*/
+
+-- GROUP BY #1
+-- PG
+EXECUTE select_pt2_group1;
+-- TG
+/* aggregate functions alias not support failed. (10)
+EXECUTE select_t2_group1_ng;
+*/
+EXECUTE select_t2_group1;
+-- GROUP BY #2
+-- PG
+EXECUTE select_pt2_group2;
+-- TG
+/* aggregate functions alias not support failed. (10)
+EXECUTE select_t2_group2_ng1;
+*/
+/* having not support failed. (10)
+EXECUTE select_t2_group2_ng2;
+*/
+-- GROUP BY #3
+-- PG
+EXECUTE select_pt2_group3;
+-- TG
+/* not support avg return data type 1700: NUMERICOID
+EXECUTE select_t2_group3_exe_ng1;
+*/
+
+-- FOREIGN TABLE JOIN
+-- TG JOIN #1
+EXECUTE select_join1;
+-- TG JOIN #2
+/* failed (10) : mismatched input 'USING'
+EXECUTE select_join2;
+*/
+-- TG JOIN #3
+EXECUTE select_join3;
+
+-- POSTGRESQL TABLE JOIN
+-- PG JOIN #1
+-- PG
+EXECUTE select_pg_join_pg1;
+-- TG
+/* tables are mixed */
+EXECUTE select_pg_join_tg1;
+-- PG JOIN #2
+-- PG
+EXECUTE select_pg_join_pg2;
+-- TG
+/* tables are mixed */
+EXECUTE select_pg_join_tg2;
+-- PG JOIN  #3
+-- PG
+EXECUTE select_pg_join_pg3;
+-- TG
+/* tables are mixed */
+EXECUTE select_pg_join_tg3;
+-- PG JOIN #4
+-- PG
+EXECUTE select_pg_join_pg4;
+-- TG
+/* tables are mixed */
+EXECUTE select_pg_join_tg4;
+-- PG JOIN #5
+-- PG
+EXECUTE select_pg_join_pg5;
+-- TG
+/* tables are mixed */
+EXECUTE select_pg_join_tg5;
+-- PG JOIN #6
+-- PG
+EXECUTE select_pg_join_pg6;
+-- TG
+EXECUTE select_pg_join_tg6;
+-- PG&TG
+/* tables are mixed */
+EXECUTE select_pg_join_pgtg6;
+-- PG JOIN #7
+-- PG
+EXECUTE select_pg_join_pg7;
+-- TG
+EXECUTE select_pg_join_tg7;
+-- PG&TG
+/* tables are mixed */
+EXECUTE select_pg_join_pgtg7;
+-- PG JOIN #8
+-- PG
+EXECUTE select_pg_join_pg8;
+-- TG
+EXECUTE select_pg_join_tg8;
+
+/***********/
+/*** DDL ***/
+/***********/
+DROP TABLE t1;
+DROP FOREIGN TABLE t1;
+DROP TABLE t2;
+DROP FOREIGN TABLE t2;
+DROP TABLE t3;
+DROP FOREIGN TABLE t3;
+DROP TABLE pt1;
+DROP TABLE pt2;
+DROP TABLE pt3;

--- a/sql/prepare_statment.sql
+++ b/sql/prepare_statment.sql
@@ -1,0 +1,97 @@
+/* SET DATASTYLE */
+SET datestyle TO ISO, ymd;
+
+/* preparation */
+-- table preparation
+CREATE TABLE trg_table (id INTEGER NOT NULL PRIMARY KEY, num INTEGER, name VARCHAR(10)) TABLESPACE tsurugi;
+CREATE FOREIGN TABLE trg_table (id INTEGER NOT NULL, num INTEGER, name VARCHAR(10)) SERVER ogawayama;
+CREATE TABLE trg_timedate (
+    id      INTEGER NOT NULL PRIMARY KEY,
+    col1    TIMESTAMP  default '2023-03-03 23:59:35.123456',
+    col2    DATE       default '1999-01-08',
+    col3    TIME       default '04:05:06.789012345',
+    col4    TIME       default '040506',
+    col5    TIME       default '04:05 AM'
+) TABLESPACE tsurugi;
+
+CREATE FOREIGN TABLE trg_timedate (
+    id      INTEGER NOT NULL,
+    col1    TIMESTAMP  default '2023-03-03 23:59:35.123456',
+    col2    DATE       default '1999-01-08',
+    col3    TIME       default '04:05:06.789012345',
+    col4    TIME       default '040506',
+    col5    TIME       default '04:05 AM'
+) SERVER ogawayama;
+
+PREPARE add_trg_table (int, int, varchar(80)) 		AS INSERT INTO trg_table (id, num, name) VALUES ($1, $2, $3);
+PREPARE add_trg_table_num (int, int) 				AS INSERT INTO trg_table (id, num, name) VALUES ($1, $2, 'zzz');
+PREPARE add_trg_table_name (int, varchar(80))		AS INSERT INTO trg_table (id, num, name) VALUES ($1, 99, $2);
+PREPARE chg_trg_table_name (int, varchar(80)) 		AS UPDATE trg_table SET name = $2 WHERE id = $1;
+PREPARE chg_trg_table_num (int, int)         		AS UPDATE trg_table SET num  = $2 WHERE id = $1;
+PREPARE chg_trg_table_88_name (int, varchar(80))	AS UPDATE trg_table SET num  = 88, name = $2 WHERE id = $1;
+PREPARE chg_trg_table_num_yyy (int, int)    		AS UPDATE trg_table SET num  = $2, name = 'yyy' WHERE id = $1;
+PREPARE all_chg_trg_table_name (varchar(80))      	AS UPDATE trg_table SET name = $1;
+PREPARE all_chg_trg_table_num (int)      			AS UPDATE trg_table SET num = $1;
+PREPARE del_trg_table_num  (int)              		AS DELETE FROM trg_table WHERE num = $1;
+PREPARE del_trg_table_name (varchar(80))      		AS DELETE FROM trg_table WHERE name = $1;
+PREPARE all_select_table							AS SELECT * FROM trg_table;
+PREPARE all_select_table_num (int)					AS SELECT * FROM trg_table WHERE num > $1;
+PREPARE all_select_table_num2 (int, int)			AS SELECT * FROM trg_table WHERE num > $1 AND num < $2;
+PREPARE all_select_table_name (varchar(80))			AS SELECT * FROM trg_table WHERE name = $1;
+
+select * from trg_table;
+
+EXECUTE add_trg_table (1, 11, 'aaa');
+select * from trg_table;
+EXECUTE add_trg_table (2, 22, 'bbb');
+select * from trg_table;
+EXECUTE add_trg_table (3, 33, 'ccc');
+select * from trg_table;
+EXECUTE add_trg_table (4, 44, 'ddd');
+select * from trg_table;
+EXECUTE add_trg_table_num (5, 55);
+select * from trg_table;
+EXECUTE add_trg_table_name (6, 'fff');
+
+select * from trg_table;
+EXECUTE all_select_table;
+select * from trg_table where num > 30;
+EXECUTE all_select_table_num(30);
+select * from trg_table where num > 20 and num < 50;
+EXECUTE all_select_table_num2(20, 50);
+select * from trg_table where name = 'fff';
+EXECUTE all_select_table_name('fff');
+
+EXECUTE chg_trg_table_name (1, 'xyz');
+select * from trg_table;
+EXECUTE chg_trg_table_num (2, 789);
+select * from trg_table;
+EXECUTE chg_trg_table_88_name (3, 'xyz');
+select * from trg_table;
+EXECUTE chg_trg_table_88_name (4, 'xyz');
+select * from trg_table;
+
+EXECUTE del_trg_table_num  (789);
+select * from trg_table;
+EXECUTE del_trg_table_name ('xyz');
+select * from trg_table;
+
+EXECUTE all_chg_trg_table_name ('abc');
+select * from trg_table;
+EXECUTE all_chg_trg_table_num (123);
+select * from trg_table;
+
+PREPARE add_trg_timedate (int)   AS INSERT INTO trg_timedate (id) VALUES ($1);
+
+EXECUTE add_trg_timedate (1);
+EXECUTE add_trg_timedate (2);
+EXECUTE add_trg_timedate (3);
+EXECUTE add_trg_timedate (4);
+EXECUTE add_trg_timedate (5);
+select * from trg_timedate;
+
+/* clean up */
+DROP FOREIGN TABLE trg_timedate;
+DROP TABLE trg_timedate;
+DROP FOREIGN TABLE trg_table;
+DROP TABLE trg_table;


### PR DESCRIPTION
JavaSE(JDBC経由)のPreparedStatementおよびPostgreSQLのPREPARE/EXECUTEコマンドに対応しました(Redmine#463)。

本対応は、[tsurugi-issues#193](https://github.com/project-tsurugi/tsurugi-issues/issues/193)の対処となります。

Javaプログラム(JDBC経由)からTsurugiトランザクションを制御する方法については、ドキュメント(docs/Transaction.md)およびサンプルコード(docs/design/Transaction/sample/transaction_sample.java)を参照のこと。

~~~
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           23 ms
test create_table                 ... ok          742 ms
test insert_select_happy          ... ok         2401 ms
test update_delete                ... ok         1375 ms
test select_statements            ... ok         1895 ms
test user_management              ... ok          820 ms
test udf_transaction              ... ok         2697 ms
test prepare_statment             ... ok         2186 ms
test prepare_select_statment      ... ok         7024 ms

=====================
 All 9 tests passed.
=====================
~~~