### PR TITLE
Fixed so that a  warning does not occur during compilation.

### DIFF
--- a/alt_function/alt_function.cpp
+++ b/alt_function/alt_function.cpp
@@ -19,6 +19,7 @@
 
 #include <boost/foreach.hpp>
 #include <boost/property_tree/ptree.hpp>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/property_tree/json_parser.hpp>
 #include <iostream>
 

--- a/tsurugi_fdw/tsurugi_fdw.cpp
+++ b/tsurugi_fdw/tsurugi_fdw.cpp
@@ -312,7 +312,6 @@ static void tsurugiGetForeignJoinPaths(PlannerInfo *root,
 static tsurugiFdwState* create_fdwstate();
 static void free_fdwstate(tsurugiFdwState* fdw_state);
 static void store_pg_data_type(tsurugiFdwState* fdw_state, List* tlist);
-static bool confirm_columns(MetadataPtr metadata, ForeignScanState* node);
 static void tsurugi_close_cursor();
 static void make_tuple_from_result_row(ResultSetPtr result_set, 
                                         TupleDesc tupleDescriptor,
@@ -2012,6 +2011,7 @@ tsurugi_close_cursor()
 //    fdw_info_.result_set = nullptr;
 }
 
+#if 0
 /*
  * confirm_columns
  * 	    Confirm column information between PostgreSQL and Ogawayama.
@@ -2189,6 +2189,7 @@ confirm_columns(MetadataPtr metadata, ForeignScanState* node)
 
 	return ret;
 }
+#endif
 
 /*
  * make_tuple_from_result_row


### PR DESCRIPTION
Fixed so that a  warning does not occur during compilation.(Redmine#509)

~~~
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           10 ms
test create_table                 ... ok          425 ms
test insert_select_happy          ... ok         1794 ms
test update_delete                ... ok         1117 ms
test select_statements            ... ok         1205 ms
test user_management              ... ok          591 ms
test udf_transaction              ... ok         2566 ms
test prepare_statment             ... ok         1611 ms
test prepare_select_statment      ... ok         4950 ms

=====================
 All 9 tests passed.
=====================
~~~
