### PR TITLE
Changed the definition name of the tsurugi database name.

### DIFF
--- a/src/common/include/tg_common.h
+++ b/src/common/include/tg_common.h
@@ -18,5 +18,5 @@
  */
 #pragma once
 
-static const char* const TG_DATABASE_NAME = "tsurugi";
+static const char* const TSURUGI_DB_NAME = "tsurugi";
 

--- a/src/tsurugi_udf/tsurugi_udf.cpp
+++ b/src/tsurugi_udf/tsurugi_udf.cpp
@@ -315,7 +315,7 @@ CheckTransactionArgs(char* TransactionType, char* TransactionPriority, char* Tra
 	}
 
 	if (WritePreserveTables != NIL) {
-		auto tables = manager::metadata::get_tables_ptr(TG_DATABASE_NAME);
+		auto tables = manager::metadata::get_tables_ptr(TSURUGI_DB_NAME);
 		ListCell* listptr;
 		foreach(listptr, WritePreserveTables) {
 			Node* node = (Node *) lfirst(listptr);

--- a/src/tsurugi_utility/alter_role/alter_role.cpp
+++ b/src/tsurugi_utility/alter_role/alter_role.cpp
@@ -67,11 +67,11 @@ bool after_alter_role(const AlterRoleStmt* stmts) {
   metadata::ObjectId object_id = 0;
 
   /* Call the function sending metadata to metadata-manager. */
-  bool success = get_roleid_by_rolename(TG_DATABASE_NAME,stmts->role->rolename, &object_id);
+  bool success = get_roleid_by_rolename(TSURUGI_DB_NAME,stmts->role->rolename, &object_id);
 
   if (success) {
     message::AlterRole alter_role{object_id};
-    std::unique_ptr<metadata::Metadata> roles{new metadata::Roles(TG_DATABASE_NAME)};
+    std::unique_ptr<metadata::Metadata> roles{new metadata::Roles(TSURUGI_DB_NAME)};
     success = send_message(&alter_role, roles);
   }
 

--- a/src/tsurugi_utility/alter_table/alter_table.cpp
+++ b/src/tsurugi_utility/alter_table/alter_table.cpp
@@ -89,7 +89,7 @@ bool AlterTable::get_constraint_metadata(Constraint* constr,
 	bool result{false};
 
 	if (constr->contype == CONSTR_FOREIGN) {
-		auto tables = metadata::get_tables_ptr(TG_DATABASE_NAME);
+		auto tables = metadata::get_tables_ptr(TSURUGI_DB_NAME);
 		metadata::ErrorCode error = metadata::ErrorCode::NOT_FOUND;
 
 		/* put constraint name metadata */

--- a/src/tsurugi_utility/alter_table/alter_table_executor.cpp
+++ b/src/tsurugi_utility/alter_table/alter_table_executor.cpp
@@ -38,7 +38,7 @@ int64_t execute_alter_table(AlterTableStmt* alter_table_stmt)
 	assert(alter_table_stmt != NULL);
 
 	ObjectId object_id = metadata::INVALID_OBJECT_ID;
-	auto tables = metadata::get_tables_ptr(TG_DATABASE_NAME);
+	auto tables = metadata::get_tables_ptr(TSURUGI_DB_NAME);
     AlterTable alter_table{alter_table_stmt};
 
     alter_table.validate_syntax();

--- a/src/tsurugi_utility/create_index/create_index.cpp
+++ b/src/tsurugi_utility/create_index/create_index.cpp
@@ -143,7 +143,7 @@ bool CreateIndex::generate_metadata(manager::metadata::Object& object) const
 	IndexStmt* index_stmt{this->index_stmt()};
 	Assert(index_stmt != NULL);
 	auto& index = static_cast<metadata::Index&>(object);
-    auto tables = metadata::get_tables_ptr(TG_DATABASE_NAME);
+    auto tables = metadata::get_tables_ptr(TSURUGI_DB_NAME);
 
     metadata::Table table;
     tables->get(this->get_table_name(), table);
@@ -272,7 +272,7 @@ CreateIndex::generate_constraint_metadata(metadata::Table& table) const
 			}
 		}
 
-		auto indexes = metadata::get_indexes_ptr(TG_DATABASE_NAME);
+		auto indexes = metadata::get_indexes_ptr(TSURUGI_DB_NAME);
 		metadata::Index index;
 		auto error = indexes->get(index_name, index);
 		if (error != metadata::ErrorCode::OK) {
@@ -303,7 +303,7 @@ CreateIndex::generate_constraint_metadata(metadata::Table& table) const
 bool get_primary_keys(IndexStmt* index_stmt, std::vector<int64_t>& primary_keys)
 {
 	bool result = false;
-    auto tables = metadata::get_tables_ptr(TG_DATABASE_NAME);
+    auto tables = metadata::get_tables_ptr(TSURUGI_DB_NAME);
 
         if (index_stmt->primary) {
 		ListCell* listptr;

--- a/src/tsurugi_utility/create_index/create_index_executor.cpp
+++ b/src/tsurugi_utility/create_index/create_index_executor.cpp
@@ -38,7 +38,7 @@ int64_t execute_create_index(IndexStmt* index_stmt)
 	assert(index_stmt != NULL);
 
 	ObjectId object_id = metadata::INVALID_OBJECT_ID;
-    auto indexes = metadata::get_indexes_ptr(TG_DATABASE_NAME);
+    auto indexes = metadata::get_indexes_ptr(TSURUGI_DB_NAME);
     CreateIndex create_index{index_stmt};
 
     create_index.validate_syntax();
@@ -64,7 +64,7 @@ int64_t execute_create_index(IndexStmt* index_stmt)
 	}
 
 	// Constraint metadata
-	auto tables = metadata::get_tables_ptr(TG_DATABASE_NAME);
+	auto tables = metadata::get_tables_ptr(TSURUGI_DB_NAME);
 	metadata::Table table_constraint;
 	error = tables->get(create_index.get_table_name(), table_constraint);
 	if (error != metadata::ErrorCode::OK) {
@@ -94,7 +94,7 @@ int64_t execute_create_index(IndexStmt* index_stmt)
 
 #if 0
 	// Primary Keys
-	auto tables = metadata::get_table_metadata(TG_DATABASE_NAME);
+	auto tables = metadata::get_table_metadata(TSURUGI_DB_NAME);
 	metadata::Table table;
 	ErrorCode error = tables->get(create_index.get_table_name(), table);
 	if (error != metadata::ErrorCode::OK) {

--- a/src/tsurugi_utility/create_role/create_role.cpp
+++ b/src/tsurugi_utility/create_role/create_role.cpp
@@ -70,7 +70,7 @@ bool after_create_role(const CreateRoleStmt* stmts) {
 
   if (success) {
     message::CreateRole cr_msg{object_id};
-    std::unique_ptr<metadata::Metadata> roles{new metadata::Roles(TG_DATABASE_NAME)};
+    std::unique_ptr<metadata::Metadata> roles{new metadata::Roles(TSURUGI_DB_NAME)};
     success = send_message(&cr_msg, roles);
   }
 

--- a/src/tsurugi_utility/create_table/create_table.cpp
+++ b/src/tsurugi_utility/create_table/create_table.cpp
@@ -250,7 +250,7 @@ bool CreateTable::validate_data_type() const
   CreateStmt* create_stmt = this->create_stmt();
   List *table_elts = create_stmt->tableElts;
   ListCell *l;
-  auto datatypes = std::make_unique<metadata::DataTypes>(TG_DATABASE_NAME);
+  auto datatypes = std::make_unique<metadata::DataTypes>(TSURUGI_DB_NAME);
 
   /*
     * List of TypeName structure's member "names" not supported by Tsurugi.
@@ -414,7 +414,7 @@ bool CreateTable::generate_column_metadata(ColumnDef* column_def,
 	assert(column_def != NULL);
 
 	bool result = false;
-	auto datatypes = std::make_unique<metadata::DataTypes>(TG_DATABASE_NAME);
+	auto datatypes = std::make_unique<metadata::DataTypes>(TSURUGI_DB_NAME);
 
 	/* ordinalPosition  */
 	column.column_number = ordinal_position;

--- a/src/tsurugi_utility/create_table/create_table_executor.cpp
+++ b/src/tsurugi_utility/create_table/create_table_executor.cpp
@@ -81,7 +81,7 @@ int64_t execute_create_table(CreateStmt* create_stmt)
 		return  object_id;
 	}
 
-	auto tables = metadata::get_tables_ptr(TG_DATABASE_NAME);
+	auto tables = metadata::get_tables_ptr(TSURUGI_DB_NAME);
 	metadata::ErrorCode error = tables->add(table, &object_id);
 	if (error != metadata::ErrorCode::OK ) {
 		if (error == metadata::ErrorCode::ALREADY_EXISTS) {
@@ -163,7 +163,7 @@ bool send_create_table_message(const int64_t object_id)
 bool remove_table_metadata(const int64_t object_id)
 {
   bool result{false};
-  auto tables = std::make_unique<metadata::Tables>(TG_DATABASE_NAME);
+  auto tables = std::make_unique<metadata::Tables>(TSURUGI_DB_NAME);
 
   if (tables->exists(object_id)) {
     metadata::ErrorCode error = tables->remove(object_id);

--- a/src/tsurugi_utility/drop_role/drop_role.cpp
+++ b/src/tsurugi_utility/drop_role/drop_role.cpp
@@ -116,7 +116,7 @@ bool after_drop_role(const DropRoleStmt* stmts, const int64_t objectIdList[]) {
 
   for (auto i = 0; i < stmts->roles->length; i++) {
     message::DropRole drop_table{objectIdList[i]};
-    std::unique_ptr<metadata::Metadata> roles{new metadata::Roles(TG_DATABASE_NAME)};
+    std::unique_ptr<metadata::Metadata> roles{new metadata::Roles(TSURUGI_DB_NAME)};
     if (!send_message(&drop_table, roles)) {
       send_message_success = false;
     }

--- a/src/tsurugi_utility/drop_table/drop_table_executor.cpp
+++ b/src/tsurugi_utility/drop_table/drop_table_executor.cpp
@@ -51,7 +51,7 @@ using namespace ogawayama;
  */
 bool table_exists_in_tsurugi(const char *relname)
 {
-  	auto tables = get_tables_ptr(TG_DATABASE_NAME);
+  	auto tables = get_tables_ptr(TSURUGI_DB_NAME);
   	return tables->exists(relname);
 }
 
@@ -77,7 +77,7 @@ bool execute_drop_table(DropStmt* drop_stmt, const char* relname)
 
     /* Get the object ID of the table to be deleted */
 	Table table;
-    auto tables = get_tables_ptr(TG_DATABASE_NAME);
+    auto tables = get_tables_ptr(TSURUGI_DB_NAME);
     metadata::ErrorCode error = tables->get(relname, table);
 	if (error != ErrorCode::OK) {
         if (error == ErrorCode::NAME_NOT_FOUND && drop_stmt->missing_ok) {
@@ -106,7 +106,7 @@ bool execute_drop_table(DropStmt* drop_stmt, const char* relname)
 
 	/* remove index metadata */
 #if 1
-	auto indexes = metadata::get_indexes_ptr(TG_DATABASE_NAME);
+	auto indexes = metadata::get_indexes_ptr(TSURUGI_DB_NAME);
 	std::vector<boost::property_tree::ptree> index_elements = {};
 	error = indexes->get_all(index_elements);
     if (error != ErrorCode::OK) {
@@ -133,7 +133,7 @@ bool execute_drop_table(DropStmt* drop_stmt, const char* relname)
 		}
 	}
 #else
-	auto indexes = metadata::get_index_metadata(TG_DATABASE_NAME);
+	auto indexes = metadata::get_index_metadata(TSURUGI_DB_NAME);
 	std::vector<metadata::Index> index_elements = {};
 	error = indexes->get_all(index_elements);
     if (error != ErrorCode::OK) {

--- a/src/tsurugi_utility/grant_revoke_role/grant_revoke_role.cpp
+++ b/src/tsurugi_utility/grant_revoke_role/grant_revoke_role.cpp
@@ -83,7 +83,7 @@ bool after_grant_revoke_role(const GrantRoleStmt* stmts) {
       ereport(ERROR,
               (errcode(ERRCODE_INVALID_GRANT_OPERATION),
                errmsg("column names cannot be included in GRANT/REVOKE ROLE")));
-    if (get_roleid_by_rolename(TG_DATABASE_NAME, rolename, &object_id)) {
+    if (get_roleid_by_rolename(TSURUGI_DB_NAME, rolename, &object_id)) {
       objectIds.push_back(object_id);
     } else {
       /* Failed getting role id.*/
@@ -95,13 +95,13 @@ bool after_grant_revoke_role(const GrantRoleStmt* stmts) {
   for (auto object_id : objectIds) {
     if (stmts->is_grant) {
       message::GrantRole grant_role{object_id};
-      std::unique_ptr<metadata::Metadata> roles{new metadata::Roles(TG_DATABASE_NAME)};
+      std::unique_ptr<metadata::Metadata> roles{new metadata::Roles(TSURUGI_DB_NAME)};
       if (!send_message(&grant_role, roles)) {
         send_message_success = false;
       }
     } else {
       message::RevokeRole revoke_role{object_id};
-      std::unique_ptr<metadata::Metadata> roles{new metadata::Roles(TG_DATABASE_NAME)};
+      std::unique_ptr<metadata::Metadata> roles{new metadata::Roles(TSURUGI_DB_NAME)};
       if (!send_message(&revoke_role, roles)) {
         send_message_success = false;
       }

--- a/src/tsurugi_utility/grant_revoke_table/grant_revoke_table.cpp
+++ b/src/tsurugi_utility/grant_revoke_table/grant_revoke_table.cpp
@@ -69,7 +69,7 @@ bool after_grant_revoke_table(const GrantStmt* stmts) {
     RangeVar* relvar = (RangeVar*) lfirst(item);
     metadata::ObjectId object_id;
 
-    if (get_tableid_by_tablename(TG_DATABASE_NAME, relvar->relname, &object_id)) {
+    if (get_tableid_by_tablename(TSURUGI_DB_NAME, relvar->relname, &object_id)) {
       objectIds.push_back(object_id);
     }
   }
@@ -78,13 +78,13 @@ bool after_grant_revoke_table(const GrantStmt* stmts) {
   for (auto object_id : objectIds) {
     if (stmts->is_grant) {
       message::GrantTable grant_table{object_id};
-      std::unique_ptr<metadata::Metadata> tables{new metadata::Tables(TG_DATABASE_NAME)};
+      std::unique_ptr<metadata::Metadata> tables{new metadata::Tables(TSURUGI_DB_NAME)};
       if (!send_message(&grant_table, tables)) {
         send_message_success = false;
       }
     } else {
       message::RevokeTable revoke_table{object_id};
-      std::unique_ptr<metadata::Metadata> tables{new metadata::Tables(TG_DATABASE_NAME)};
+      std::unique_ptr<metadata::Metadata> tables{new metadata::Tables(TSURUGI_DB_NAME)};
       if (!send_message(&revoke_table, tables)) {
         send_message_success = false;
       }

--- a/src/tsurugi_utility/prepare_execute/prepare_execute.cpp
+++ b/src/tsurugi_utility/prepare_execute/prepare_execute.cpp
@@ -144,7 +144,7 @@ is_tsurugi_table(Node* query,
 			return result;
 	}
 
-	auto tables = manager::metadata::get_tables_ptr(TG_DATABASE_NAME);
+	auto tables = manager::metadata::get_tables_ptr(TSURUGI_DB_NAME);
 	for(std::size_t i = 0; i < target_tables.size(); i++) {
 		if (tables->exists(target_tables[i])) {
 			is_tsurugi = true;


### PR DESCRIPTION
Changed the definition name of the tsurugi database name.(Redmine#511)

~~~
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok            8 ms
test create_table                 ... ok          315 ms
test insert_select_happy          ... ok         1543 ms
test update_delete                ... ok          878 ms
test select_statements            ... ok         1211 ms
test user_management              ... ok          513 ms
test udf_transaction              ... ok         2394 ms
test prepare_statment             ... ok         1487 ms
test prepare_select_statment      ... ok         4776 ms

=====================
 All 9 tests passed.
=====================
~~~