### PR TITLE
Secondary index operations are not yet supported.

### DIFF
--- a/src/tsurugi_utility/drop_index/drop_index_executor.cpp
+++ b/src/tsurugi_utility/drop_index/drop_index_executor.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2022-2023 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *	@file	drop_index_executor.cpp
+ */
+#include "tg_common.h"
+#include "ogawayama/stub/api.h"
+
+#include "manager/message/ddl_message.h"
+#include "manager/metadata/datatypes.h"
+#include "manager/metadata/metadata.h"
+#include "manager/metadata/index.h"
+#include "manager/metadata/indexes.h"
+#include "manager/metadata/metadata_factory.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+#include "postgres.h"
+#include "nodes/parsenodes.h"
+#ifdef __cplusplus
+}
+#endif
+
+#include "tsurugi.h"
+#include "send_message.h"
+#include "drop_index_executor.h"
+#include "drop_index.h"
+#include "manager/metadata/metadata.h"
+
+using namespace boost;
+using namespace manager;
+using namespace manager::metadata;
+using namespace ogawayama;
+
+/**
+ *  @brief
+ *  @param
+ */
+bool index_exists_in_tsurugi(const char* index_name)
+{
+  	auto indexes = get_indexes_ptr(TSURUGI_DB_NAME);
+  	return indexes->exists(index_name);
+}
+
+/**
+ *  @brief Calls the function sending metadata to metadata-manager and drops parameters sended to ogawayama.
+ */
+bool execute_drop_index(DropStmt* drop_stmt, const char* index_name)
+{
+    Assert(drop_stmt != nullptr);
+
+	elog(LOG, "execute_drop_index() started.");
+
+	bool result{false};
+	DropIndex drop_index(drop_stmt);
+
+	bool success = drop_index.validate_syntax();
+	if (!success) {
+		return result;
+	}
+
+	success = drop_index.validate_data_type();
+	if (!success) {
+		return result;
+	}
+
+    /* Get the object ID of the index to be deleted */
+	manager::metadata::Index index;
+    auto indexes = get_indexes_ptr(TSURUGI_DB_NAME);
+    metadata::ErrorCode error = indexes->get(index_name, index);
+	if (error != ErrorCode::OK) {
+        if (error == ErrorCode::NAME_NOT_FOUND && drop_stmt->missing_ok) {
+            result = true;
+        } else {
+            ereport(ERROR,
+                    (errcode(ERRCODE_INTERNAL_ERROR),
+                     errmsg("drop_index() get metadata failed. (table name: %s)", 
+                     index_name)));
+        }
+        return result;
+    }
+
+	// check constraint
+	Table table;
+	auto tables = get_tables_ptr(TSURUGI_DB_NAME);
+	error = tables->get(index.table_id, table);
+	if (error != ErrorCode::OK) {
+		ereport(ERROR,
+			(errcode(ERRCODE_INTERNAL_ERROR),
+			 errmsg("drop_index() get table metadata failed.")));
+		return result;
+	}
+	for (const auto& constraint : table.constraints) {
+		if (index.id == constraint.index_id) {
+			ereport(ERROR,
+					(errcode(ERRCODE_DEPENDENT_OBJECTS_STILL_EXIST),
+					 errmsg("cannot drop index because constraint %s on table %s requires it",
+					 index.name.data(), table.name.data())));
+			return result;
+		}
+	}
+
+    /* Send DROP_INDEX message to ogawayama */
+    message::DropIndex drop_index_message{index.id};
+    success = send_message(drop_index_message);
+    if (!success) {
+      ereport(ERROR,
+              (errcode(ERRCODE_INTERNAL_ERROR), 
+              errmsg("send_message() failed. (DROP_INDEX)")));
+      return result;
+    }
+
+	/* remove index metadata */
+    error = indexes->remove(index.id);
+    if (error != ErrorCode::OK) {
+        ereport(ERROR,
+                (errcode(ERRCODE_INTERNAL_ERROR),
+                 errmsg("drop_index() remove index metadata failed.")));
+        return result;
+    }
+	result = true;
+
+    return result;
+}

--- a/src/tsurugi_utility/include/drop_index.h
+++ b/src/tsurugi_utility/include/drop_index.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022-2023 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *	@file	drop_index.h
+ */
+#pragma once
+#include "command/drop_command.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "nodes/parsenodes.h"
+#ifdef __cplusplus
+}
+#endif
+
+class DropIndex : public DropCommand {
+ public:
+	DropIndex(DropStmt* drop_stmt) : DropCommand(drop_stmt) {}
+
+	/**
+	 * @brief
+	 */
+	virtual bool validate_syntax() const {
+		DropStmt* drop_stmt = this->drop_stmt();
+		assert(drop_stmt != nullptr);
+		bool result{false};
+
+		if (drop_stmt->behavior == DROP_CASCADE) {
+			ereport(ERROR,
+					(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+					errmsg("Tsurugi does not support CASCADE clause")));
+			return result;
+		}
+		result = true;
+
+		return result;
+	}
+
+	/**
+	 * @brief
+	 */
+	virtual bool validate_data_type() const { return true; }
+
+	DropIndex() = delete;
+	DropIndex(const DropIndex&) = delete;
+  	DropIndex& operator=(const DropIndex&) = delete;
+};

--- a/src/tsurugi_utility/include/drop_index_executor.h
+++ b/src/tsurugi_utility/include/drop_index_executor.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022-2023 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *	@file	drop_index_executor.h
+ */
+#ifndef DROP_INDEX_EXECUTOR_H
+#define DROP_INDEX_EXECUTOR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "nodes/parsenodes.h"
+
+bool index_exists_in_tsurugi(const char* index_name);
+bool execute_drop_index(DropStmt* drop_stmt, const char* index_name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DROP_INDEX_EXECUTOR_H


### PR DESCRIPTION
Secondary index operations are not yet supported.

~~~
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           11 ms
test create_table                 ... ok          179 ms
test insert_select_happy          ... ok          763 ms
test update_delete                ... ok          382 ms
test select_statements            ... ok          722 ms
test user_management              ... ok          198 ms
test udf_transaction              ... ok         2094 ms
test prepare_statment             ... ok          683 ms
test prepare_select_statment      ... ok         2200 ms
test manual_tutorial              ... ok          339 ms

======================
 All 10 tests passed.
======================
~~~