### PR TITLE
Fixed that data types not supported by tsurugi_fdw could be defined with CREATE TABLE.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,11 @@ DATA = tsurugi_fdw--1.0.0-BETA4.sql
 # REGRESS_BASIC: variable used in frontend
 #REGRESS_BASIC = test_create_table otable_of_constr ch-benchmark-ddl create_table_syntax_type update_delete insert_select
 REGRESS_BASIC = test_preparation create_table create_index insert_select_happy update_delete select_statements user_management \
-                udf_transaction prepare_statment prepare_select_statment prepare_decimal
+                udf_transaction prepare_statment prepare_select_statment prepare_decimal manual_tutorial data_types
 ifdef REGRESS_EXTRA
 	# REGRESS: variable defined in PostgreSQL
-	#REGRESS = $(REGRESS_BASIC) otable_of_constr2
-	REGRESS = $(REGRESS_BASIC) manual_tutorial
+	# REGRESS = $(REGRESS_BASIC) otable_of_constr2
+	REGRESS = $(REGRESS_BASIC)
 else
 	# REGRESS: variable defined in PostgreSQL
 	REGRESS = $(REGRESS_BASIC)

--- a/expected/data_types.out
+++ b/expected/data_types.out
@@ -1,0 +1,42 @@
+/* Numeric Types */
+-- supported
+CREATE TABLE numeric1(c1 integer) TABLESPACE tsurugi;
+CREATE TABLE numeric2(c1 bigint) TABLESPACE tsurugi;
+CREATE TABLE numeric3(c1 decimal(5, 2)) TABLESPACE tsurugi;
+CREATE TABLE numeric4(c1 numeric(5, 2)) TABLESPACE tsurugi;
+CREATE TABLE numeric5(c1 real) TABLESPACE tsurugi;
+CREATE TABLE numeric6(c1 double precision) TABLESPACE tsurugi;
+-- not supported
+CREATE TABLE numeric99(c1 smallint) TABLESPACE tsurugi;
+ERROR:  Tsurugi does not support type (("pg_catalog" "int2"))
+/* Character Types */
+-- supported
+CREATE TABLE character1(c1 character varying(10)) TABLESPACE tsurugi;
+CREATE TABLE character2(c1 character(10)) TABLESPACE tsurugi;
+-- not supported
+CREATE TABLE character99(c1 text) TABLESPACE tsurugi;
+ERROR:  Tsurugi does not support type (("text"))
+/* Date/Time Types */
+-- supported
+CREATE TABLE datetime1(c1 timestamp) TABLESPACE tsurugi;
+CREATE TABLE datetime2(c1 date) TABLESPACE tsurugi;
+CREATE TABLE datetime3(c1 time) TABLESPACE tsurugi;
+-- not supported
+CREATE TABLE datetime99(c1 timestamp with time zone) TABLESPACE tsurugi;
+ERROR:  Tsurugi does not support type (("pg_catalog" "timestamptz"))
+CREATE TABLE datetime98(c1 time with time zone) TABLESPACE tsurugi;
+ERROR:  Tsurugi does not support type (("pg_catalog" "timetz"))
+CREATE TABLE datetime97(c1 interval) TABLESPACE tsurugi;
+ERROR:  Tsurugi does not support type (("pg_catalog" "interval"))
+/* clean up */
+DROP TABLE numeric1;
+DROP TABLE numeric2;
+DROP TABLE numeric3;
+DROP TABLE numeric4;
+DROP TABLE numeric5;
+DROP TABLE numeric6;
+DROP TABLE character1;
+DROP TABLE character2;
+DROP TABLE datetime1;
+DROP TABLE datetime2;
+DROP TABLE datetime3;

--- a/sql/data_types.sql
+++ b/sql/data_types.sql
@@ -1,0 +1,45 @@
+/* Numeric Types */
+-- supported
+CREATE TABLE numeric1(c1 integer) TABLESPACE tsurugi;
+CREATE TABLE numeric2(c1 bigint) TABLESPACE tsurugi;
+CREATE TABLE numeric3(c1 decimal(5, 2)) TABLESPACE tsurugi;
+CREATE TABLE numeric4(c1 numeric(5, 2)) TABLESPACE tsurugi;
+CREATE TABLE numeric5(c1 real) TABLESPACE tsurugi;
+CREATE TABLE numeric6(c1 double precision) TABLESPACE tsurugi;
+
+-- not supported
+CREATE TABLE numeric99(c1 smallint) TABLESPACE tsurugi;
+
+/* Character Types */
+-- supported
+CREATE TABLE character1(c1 character varying(10)) TABLESPACE tsurugi;
+CREATE TABLE character2(c1 character(10)) TABLESPACE tsurugi;
+
+-- not supported
+CREATE TABLE character99(c1 text) TABLESPACE tsurugi;
+
+/* Date/Time Types */
+-- supported
+CREATE TABLE datetime1(c1 timestamp) TABLESPACE tsurugi;
+CREATE TABLE datetime2(c1 date) TABLESPACE tsurugi;
+CREATE TABLE datetime3(c1 time) TABLESPACE tsurugi;
+
+-- not supported
+CREATE TABLE datetime99(c1 timestamp with time zone) TABLESPACE tsurugi;
+CREATE TABLE datetime98(c1 time with time zone) TABLESPACE tsurugi;
+CREATE TABLE datetime97(c1 interval) TABLESPACE tsurugi;
+
+/* clean up */
+DROP TABLE numeric1;
+DROP TABLE numeric2;
+DROP TABLE numeric3;
+DROP TABLE numeric4;
+DROP TABLE numeric5;
+DROP TABLE numeric6;
+
+DROP TABLE character1;
+DROP TABLE character2;
+
+DROP TABLE datetime1;
+DROP TABLE datetime2;
+DROP TABLE datetime3;


### PR DESCRIPTION
Fixed that data types not supported by tsurugi_fdw could be defined with CREATE TABLE.

~~~
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           18 ms
test create_table                 ... ok          798 ms
test create_index                 ... ok         1590 ms
test insert_select_happy          ... ok          905 ms
test update_delete                ... ok          621 ms
test select_statements            ... ok          830 ms
test user_management              ... ok          211 ms
test udf_transaction              ... ok          954 ms
test prepare_statment             ... ok         1888 ms
test prepare_select_statment      ... ok         2300 ms
test prepare_decimal              ... ok         1075 ms
test manual_tutorial              ... ok          371 ms
test data_types                   ... ok          274 ms

======================
 All 13 tests passed.
======================
~~~