### PR TITLE
Fixed to erase standard schema name from query string.

### DIFF
--- a/expected/create_table.out
+++ b/expected/create_table.out
@@ -78,6 +78,57 @@ SELECT * FROM t1;
  100
 (2 rows)
 
+/* Fix tsurugi-issues#568 */
+INSERT INTO public.t1 (c1) VALUES (1000);
+INSERT INTO PuBlIc.t1 (c1) VALUES (2000);
+INSERT INTO PUBLIC.t1 (c1) VALUES (3000);
+INSERT INTO "public"."t1" (c1) VALUES (4000);
+SELECT * FROM public.t1;
+  c1  
+------
+    1
+  100
+ 1000
+ 2000
+ 3000
+ 4000
+(6 rows)
+
+UPDATE public.t1 SET c1 = c1+100;
+UPDATE PuBlIc.t1 SET c1 = c1+100 WHERE c1 > 1000;
+UPDATE public.t1 SET c1 = c1+100 WHERE c1 > 2000;
+UPDATE "public"."t1" SET c1 = c1+100 WHERE c1 > 3000;
+SELECT * FROM "public"."t1";
+  c1  
+------
+  101
+  200
+ 1200
+ 2300
+ 3400
+ 4400
+(6 rows)
+
+DELETE FROM public.t1 WHERE c1 = 200;
+DELETE FROM "public"."t1" WHERE c1 > 1000;
+SELECT * FROM Public.t1;
+ c1  
+-----
+ 101
+(1 row)
+
+INSERT INTO "puBlIc"."t1" (c1) VALUES (999); -- error
+ERROR:  relation "puBlIc.t1" does not exist
+LINE 1: INSERT INTO "puBlIc"."t1" (c1) VALUES (999);
+                    ^
+UPDATE "PUBLIC"."t1" SET c1 = c1+100; -- error
+ERROR:  relation "PUBLIC.t1" does not exist
+LINE 1: UPDATE "PUBLIC"."t1" SET c1 = c1+100;
+               ^
+DELETE FROM "Public"."t1" WHERE c1 > 1000; -- error
+ERROR:  relation "Public.t1" does not exist
+LINE 1: DELETE FROM "Public"."t1" WHERE c1 > 1000;
+                    ^
 /* DDL */
 DROP TABLE t1;
 DROP TABLE t2;

--- a/sql/create_table.sql
+++ b/sql/create_table.sql
@@ -29,6 +29,30 @@ SELECT * FROM t1;
 DELETE FROM t1 WHERE c1 = 10;
 SELECT * FROM t1;
 
+/* Fix tsurugi-issues#568 */
+INSERT INTO public.t1 (c1) VALUES (1000);
+INSERT INTO PuBlIc.t1 (c1) VALUES (2000);
+INSERT INTO PUBLIC.t1 (c1) VALUES (3000);
+INSERT INTO "public"."t1" (c1) VALUES (4000);
+
+SELECT * FROM public.t1;
+
+UPDATE public.t1 SET c1 = c1+100;
+UPDATE PuBlIc.t1 SET c1 = c1+100 WHERE c1 > 1000;
+UPDATE public.t1 SET c1 = c1+100 WHERE c1 > 2000;
+UPDATE "public"."t1" SET c1 = c1+100 WHERE c1 > 3000;
+
+SELECT * FROM "public"."t1";
+
+DELETE FROM public.t1 WHERE c1 = 200;
+DELETE FROM "public"."t1" WHERE c1 > 1000;
+
+SELECT * FROM Public.t1;
+
+INSERT INTO "puBlIc"."t1" (c1) VALUES (999); -- error
+UPDATE "PUBLIC"."t1" SET c1 = c1+100; -- error
+DELETE FROM "Public"."t1" WHERE c1 > 1000; -- error
+
 /* DDL */
 DROP TABLE t1;
 DROP TABLE t2;

--- a/src/tsurugi_fdw/tsurugi_utils.cpp
+++ b/src/tsurugi_fdw/tsurugi_utils.cpp
@@ -33,6 +33,9 @@ extern "C" {
 
 using namespace ogawayama;
 
+static const std::string PIBLIC_SCHEMA_NAME = "public\\.";
+static const std::string PIBLIC_DOUBLE_QUOTATION = "\"public\"\\.";
+
 /*
  *  
  */
@@ -41,6 +44,21 @@ std::string make_tsurugi_query(std::string_view query_string)
     std::string tsurugi_query(query_string);
 
 	elog(DEBUG1, "tsurugi_fdw : raw query string : \"%s\"", query_string.data());
+
+	// erase public schema.
+	std::smatch regex_match;
+	std::regex regex_public(PIBLIC_SCHEMA_NAME, std::regex_constants::icase);
+	while(std::regex_search(tsurugi_query, regex_match, regex_public)) {
+		std::string::size_type erase_pos = tsurugi_query.find(regex_match.str(0));
+		std::size_t erase_size = regex_match.str(0).size();
+		tsurugi_query.erase(erase_pos, erase_size);
+	}
+	std::regex regex_double_quotation(PIBLIC_DOUBLE_QUOTATION);
+	while(std::regex_search(tsurugi_query, regex_match, regex_double_quotation)) {
+		std::string::size_type erase_pos = tsurugi_query.find(regex_match.str(0));
+		std::size_t erase_size = regex_match.str(0).size();
+		tsurugi_query.erase(erase_pos, erase_size);
+	}
 
     // trim terminal semi-column.
     if (tsurugi_query.back() == ';') 

--- a/src/tsurugi_fdw/tsurugi_utils.cpp
+++ b/src/tsurugi_fdw/tsurugi_utils.cpp
@@ -33,8 +33,8 @@ extern "C" {
 
 using namespace ogawayama;
 
-static const std::string PIBLIC_SCHEMA_NAME = "public\\.";
-static const std::string PIBLIC_DOUBLE_QUOTATION = "\"public\"\\.";
+static const std::string PUBLIC_SCHEMA_NAME = "public\\.";
+static const std::string PUBLIC_DOUBLE_QUOTATION = "\"public\"\\.";
 
 /*
  *  
@@ -47,13 +47,13 @@ std::string make_tsurugi_query(std::string_view query_string)
 
 	// erase public schema.
 	std::smatch regex_match;
-	std::regex regex_public(PIBLIC_SCHEMA_NAME, std::regex_constants::icase);
+	std::regex regex_public(PUBLIC_SCHEMA_NAME, std::regex_constants::icase);
 	while(std::regex_search(tsurugi_query, regex_match, regex_public)) {
 		std::string::size_type erase_pos = tsurugi_query.find(regex_match.str(0));
 		std::size_t erase_size = regex_match.str(0).size();
 		tsurugi_query.erase(erase_pos, erase_size);
 	}
-	std::regex regex_double_quotation(PIBLIC_DOUBLE_QUOTATION);
+	std::regex regex_double_quotation(PUBLIC_DOUBLE_QUOTATION);
 	while(std::regex_search(tsurugi_query, regex_match, regex_double_quotation)) {
 		std::string::size_type erase_pos = tsurugi_query.find(regex_match.str(0));
 		std::size_t erase_size = regex_match.str(0).size();


### PR DESCRIPTION
Fixed to erase standard (public) schema name from query string.
https://github.com/project-tsurugi/tsurugi-issues/issues/568

~~~log
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           11 ms
test create_table                 ... ok          893 ms
test create_index                 ... ok         1575 ms
test insert_select_happy          ... ok         1025 ms
test update_delete                ... ok          640 ms
test select_statements            ... ok          907 ms
test user_management              ... ok          235 ms
test udf_transaction              ... ok         1014 ms
test prepare_statment             ... ok         1792 ms
test prepare_select_statment      ... ok         2279 ms
test prepare_decimal              ... ok         1067 ms
test manual_tutorial              ... ok          369 ms
test data_types                   ... ok          379 ms

======================
 All 13 tests passed.
======================
~~~