### PR TITLE
Fixed issue that exception if multiple rows were specified for INSERT VALUES.

### DIFF
--- a/expected/insert_select_happy.out
+++ b/expected/insert_select_happy.out
@@ -199,6 +199,8 @@ SELECT * FROM integer1;
   2147483647
 (8 rows)
 
+INSERT INTO integer1 (ol_w_id) VALUES (9), (8), (7);  -- see tsurugi-issues#770
+ERROR:  Tsurugi::execute_statement() failed. (10)
 INSERT INTO integer1 (ol_w_id) VALUES (1.1);  -- see tsurugi-issues#736
 ERROR:  Tsurugi::execute_statement() failed. (10)
 INSERT INTO integer1 (ol_w_id) VALUES (cast(1.1 as int));

--- a/sql/insert_select_happy.sql
+++ b/sql/insert_select_happy.sql
@@ -134,6 +134,8 @@ SELECT * FROM integer1;
 INSERT INTO integer1 (ol_w_id) VALUES (-2147483648); --min
 SELECT * FROM integer1;
 
+INSERT INTO integer1 (ol_w_id) VALUES (9), (8), (7);  -- see tsurugi-issues#770
+
 INSERT INTO integer1 (ol_w_id) VALUES (1.1);  -- see tsurugi-issues#736
 INSERT INTO integer1 (ol_w_id) VALUES (cast(1.1 as int));
 SELECT * FROM integer1;

--- a/src/tsurugi_planner/tsurugi_planner.c
+++ b/src/tsurugi_planner/tsurugi_planner.c
@@ -249,7 +249,8 @@ is_only_foreign_table(AltPlannerInfo *root, List *rtable)
 			case RTE_VALUES:
 			case RTE_NAMEDTUPLESTORE:
 			{
-				return false;
+                elog(LOG, "tsurugi_fdw : Whether or not support is provided will be " \
+						"determined by Tsurugi. rtekind = %d", range_table_entry->rtekind);
 				break;
 			}
 		}

--- a/src/tsurugi_planner/tsurugi_planner.c
+++ b/src/tsurugi_planner/tsurugi_planner.c
@@ -248,6 +248,7 @@ is_only_foreign_table(AltPlannerInfo *root, List *rtable)
 			case RTE_TABLEFUNC:
 			case RTE_VALUES:
 			case RTE_NAMEDTUPLESTORE:
+			default:
 			{
                 elog(LOG, "tsurugi_fdw : Whether or not support is provided will be " \
 						"determined by Tsurugi. rtekind = %d", range_table_entry->rtekind);


### PR DESCRIPTION
Fixed issue that exception if multiple rows were specified for INSERT VALUES.
https://github.com/project-tsurugi/tsurugi-issues/issues/770

~~~log
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           13 ms
test create_table                 ... ok          841 ms
test create_index                 ... ok         1535 ms
test insert_select_happy          ... ok          966 ms
test update_delete                ... ok          624 ms
test select_statements            ... ok          972 ms
test user_management              ... ok          216 ms
test udf_transaction              ... ok         1089 ms
test prepare_statment             ... ok         1987 ms
test prepare_select_statment      ... ok         2409 ms
test prepare_decimal              ... ok         1188 ms
test manual_tutorial              ... ok          382 ms
test data_types                   ... ok          309 ms

======================
 All 13 tests passed.
======================
~~~
