### PR TITLE
Fixed a regression tests failure that oucurre due to a specification change in Tsurugi1.0.0-BETA6.

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -105,6 +105,7 @@ runs:
         repository: project-tsurugi/ogawayama
         path: ${{ inputs.path }}/ogawayama
         ref: master
+        submodules: recursive
 
     - name: Checkout_Metadata_Manager
       uses: actions/checkout@v3

--- a/expected/prepare_select_statment.out
+++ b/expected/prepare_select_statment.out
@@ -191,8 +191,6 @@ PREPARE select_pt2_where6
 /* tsurugi-issue#69 */
 PREPARE select_t2_where6
 	AS SELECT * FROM t2 WHERE c4 BETWEEN 2.2 AND 5.5;
-ERROR:  Tsurugi::prepare() failed. (10)
-	sql:SELECT * FROM t2 WHERE c4 BETWEEN 2.200000 AND 5.500000 
 -- WHERE #7
 -- PG
 PREPARE select_pt1_where7
@@ -221,8 +219,6 @@ PREPARE select_pt2_where9
 /* tsurugi-issue#70 */
 PREPARE select_t2_where9
 	AS SELECT * FROM t2 WHERE c4 IN (1.1,3.3);
-ERROR:  Tsurugi::prepare() failed. (10)
-	sql:SELECT * FROM t2 WHERE c4 IN (1.100000 , 3.300000 )
 -- GROUP BY #1
 -- PG
 PREPARE select_pt2_group1
@@ -691,9 +687,15 @@ EXECUTE select_pt2_where6;
 (3 rows)
 
 -- TG
-/* tsurugi-issue#69
+/* tsurugi-issue#69 */
 EXECUTE select_t2_where6;
-*/
+ c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+-----
+  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+(3 rows)
+
 -- WHERE #7
 -- PG
 EXECUTE select_pt1_where7;

--- a/sql/prepare_select_statment.sql
+++ b/sql/prepare_select_statment.sql
@@ -454,9 +454,8 @@ EXECUTE select_t1_where5;
 -- PG
 EXECUTE select_pt2_where6;
 -- TG
-/* tsurugi-issue#69
+/* tsurugi-issue#69 */
 EXECUTE select_t2_where6;
-*/
 -- WHERE #7
 -- PG
 EXECUTE select_pt1_where7;


### PR DESCRIPTION
Fixed a regression tests failure that oucurre due to a specification change in Tsurugi1.0.0-BETA6.
(https://github.com/project-tsurugi/tsurugi-issues/issues/69, https://github.com/project-tsurugi/tsurugi-issues/issues/70)

~~~log
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           10 ms
test create_table                 ... ok          781 ms
test create_index                 ... ok         1498 ms
test insert_select_happy          ... ok          878 ms
test update_delete                ... ok          558 ms
test select_statements            ... ok          486 ms
test user_management              ... ok          225 ms
test udf_transaction              ... ok          870 ms
test prepare_statment             ... ok         1733 ms
test prepare_select_statment      ... ok         2174 ms
test prepare_decimal              ... ok         1101 ms
test manual_tutorial              ... ok          307 ms
test data_types                   ... ok          268 ms

======================
 All 13 tests passed.
======================
~~~