### PR TITLE
Fixed the rewriting process of the elements in the GROUP BY clause.

### DIFF
--- a/expected/prepare_select_statment.out
+++ b/expected/prepare_select_statment.out
@@ -249,6 +249,7 @@ PREPARE select_t2_group2
 PREPARE select_pt2_group3
 	AS SELECT c7, count(c1), sum(c2), avg(c3), min(c4), max(c5) FROM pt2 GROUP BY c7;
 -- TG
+/* tsurugi-issue#974 : Restrictions of the AGV aggregation function */
 PREPARE select_t2_group3_exe_ng1
 	AS SELECT c7, count(c1), sum(c2), avg(c3), min(c4), max(c5) FROM t2 GROUP BY c7;
 -- FOREIGN TABLE JOIN
@@ -789,7 +790,7 @@ EXECUTE select_pt2_group3;
 (3 rows)
 
 -- TG
-/* not support avg return data type 1700: NUMERICOID
+/* tsurugi-issue#974 : Restrictions of the AGV aggregation function
 EXECUTE select_t2_group3_exe_ng1;
 */
 -- FOREIGN TABLE JOIN

--- a/expected/select_statements.out
+++ b/expected/select_statements.out
@@ -710,7 +710,13 @@ FROM
     t2
 GROUP BY
     c7;
-ERROR:  Query execution failed. (10)
+ count(c1) | sum(c2) | c7  
+-----------+---------+-----
+         1 |         | 
+         2 |      44 | ABC
+         2 |      77 | XYZ
+(3 rows)
+
 -- GROUP BY #2
 -- PG
 SELECT
@@ -735,7 +741,11 @@ GROUP BY
     c7
 HAVING 
     sum(c2) > 55;
-ERROR:  Query execution failed. (10)
+ count(c1) | sum(c2) | c7  
+-----------+---------+-----
+         2 |      77 | XYZ
+(1 row)
+
 -- GROUP BY #3
 -- PG
 SELECT
@@ -752,19 +762,14 @@ GROUP BY
 (3 rows)
 
 -- TG
+/* tsurugi-issue#974 : Restrictions of the AGV aggregation function
 SELECT
     c7, count(c1), sum(c2), avg(c3), min(c4), max(c5)
 FROM
-    pt2
+    t2
 GROUP BY
     c7;
- c7  | count | sum |         avg          | min | max  
------+-------+-----+----------------------+-----+------
-     |     1 |     |                      |     |     
- ABC |     2 |  44 | 222.0000000000000000 | 1.1 | 3.33
- XYZ |     2 |  77 | 388.5000000000000000 | 2.2 | 5.55
-(3 rows)
-
+*/
 -- FOREIGN TABLE JOIN
 -- TG JOIN #1 /* tsurugi-issue#863 */
 SELECT 

--- a/sql/prepare_select_statment.sql
+++ b/sql/prepare_select_statment.sql
@@ -253,6 +253,7 @@ PREPARE select_t2_group2
 PREPARE select_pt2_group3
 	AS SELECT c7, count(c1), sum(c2), avg(c3), min(c4), max(c5) FROM pt2 GROUP BY c7;
 -- TG
+/* tsurugi-issue#974 : Restrictions of the AGV aggregation function */
 PREPARE select_t2_group3_exe_ng1
 	AS SELECT c7, count(c1), sum(c2), avg(c3), min(c4), max(c5) FROM t2 GROUP BY c7;
 
@@ -498,10 +499,9 @@ EXECUTE select_t2_group2;
 -- PG
 EXECUTE select_pt2_group3;
 -- TG
-/* not support avg return data type 1700: NUMERICOID
+/* tsurugi-issue#974 : Restrictions of the AGV aggregation function
 EXECUTE select_t2_group3_exe_ng1;
 */
-
 -- FOREIGN TABLE JOIN
 -- TG JOIN #1
 EXECUTE select_join1;

--- a/sql/select_statements.sql
+++ b/sql/select_statements.sql
@@ -502,13 +502,14 @@ GROUP BY
     c7;
 
 -- TG
+/* tsurugi-issue#974 : Restrictions of the AGV aggregation function
 SELECT
     c7, count(c1), sum(c2), avg(c3), min(c4), max(c5)
 FROM
-    pt2
+    t2
 GROUP BY
     c7;
-
+*/
 -- FOREIGN TABLE JOIN
 -- TG JOIN #1 /* tsurugi-issue#863 */
 SELECT 

--- a/src/tsurugi_fdw/deparse.c
+++ b/src/tsurugi_fdw/deparse.c
@@ -3178,7 +3178,7 @@ appendGroupByClause(List *tlist, deparse_expr_cxt *context)
 			appendStringInfoString(buf, ", ");
 		first = false;
 
-		deparseSortGroupClause(grp->tleSortGroupRef, tlist, true, context);
+		deparseSortGroupClause(grp->tleSortGroupRef, tlist, false, context);
 	}
 }
 


### PR DESCRIPTION
Fixed the rewriting process of the elements in the GROUP BY clause.
https://github.com/project-tsurugi/tsurugi-issues/issues/958

~~~
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           12 ms
test create_table                 ... ok          761 ms
test create_index                 ... ok         1418 ms
test insert_select_happy          ... ok         1033 ms
test update_delete                ... ok          571 ms
test select_statements            ... ok          519 ms
test user_management              ... ok          215 ms
test udf_transaction              ... ok          887 ms
test prepare_statment             ... ok         2049 ms
test prepare_select_statment      ... ok         2091 ms
test prepare_decimal              ... ok         1148 ms
test manual_tutorial              ... ok          315 ms
test data_types                   ... ok          308 ms

======================
 All 13 tests passed.
======================
~~~