### PR TITLE
Unhooked the user management and access control.

### DIFF
--- a/expected/user_management.out
+++ b/expected/user_management.out
@@ -246,11 +246,11 @@ ERROR:  syntax error at or near "sample_role2"
 LINE 1: REVOKE ROLE sample_role2, unknown_role FROM sample_role1;
                     ^
 DROP ROLE unknown_role;
-ERROR:  Could not get role.
+ERROR:  role "unknown_role" does not exist
 DROP ROLE unknown_role, sample_role2;
-ERROR:  Could not get role.
+ERROR:  role "unknown_role" does not exist
 DROP ROLE sample_role2, unknown_role;
-ERROR:  Could not get role.
+ERROR:  role "unknown_role" does not exist
 GRANT SELECT, INSERT, UPDATE, DELETE ON t4_user_management to sample_role2;
 ERROR:  relation "t4_user_management" does not exist
 GRANT SELECT, INSERT, UPDATE, DELETE ON t4_user_management, t3_user_management to sample_role2;

--- a/src/tsurugi_utility/tsurugi_utility.c
+++ b/src/tsurugi_utility/tsurugi_utility.c
@@ -132,17 +132,6 @@ tsurugi_ProcessUtility(PlannedStmt *pstmt,
             break;
 		}
 
-		case T_CreateRoleStmt:
-		{
-			standard_ProcessUtility(pstmt, queryString, context, params, queryEnv,
-									dest, completionTag);
-			if (!after_create_role((CreateRoleStmt*)parsetree)) 
-			{
-				elog(ERROR, "failed after_create_role() function.");
-			}
-			break;
-		}
-
 		case T_CreateForeignTableStmt:
 		{
 			if (IsTsurugifdwInstalled())
@@ -173,6 +162,18 @@ tsurugi_ProcessUtility(PlannedStmt *pstmt,
 			}
 			standard_ProcessUtility(pstmt, queryString, context, params, queryEnv,
 									dest, completionTag);
+			break;
+		}
+
+#if 0 // Since user and access control is not implemented in Tsurugi, it runs on the standard.
+		case T_CreateRoleStmt:
+		{
+			standard_ProcessUtility(pstmt, queryString, context, params, queryEnv,
+									dest, completionTag);
+			if (!after_create_role((CreateRoleStmt*)parsetree))
+			{
+				elog(ERROR, "failed after_create_role() function.");
+			}
 			break;
 		}
 
@@ -278,6 +279,7 @@ tsurugi_ProcessUtility(PlannedStmt *pstmt,
 			}
 			break;
 		}
+#endif // Since user and access control is not implemented in Tsurugi, it runs on the standard.
 
 		case T_PrepareStmt:
 		{


### PR DESCRIPTION
Unhooked the user management and access control.

~~~
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           28 ms
test create_table                 ... ok          113 ms
test create_index                 ... ok           68 ms
test insert_select_happy          ... ok          308 ms
test update_delete                ... ok          227 ms
test select_statements            ... ok          154 ms
test user_management              ... ok           22 ms
test udf_transaction              ... ok          510 ms
test prepare_statment             ... ok          409 ms
test prepare_select_statment      ... ok          158 ms
test prepare_decimal              ... ok          215 ms
test manual_tutorial              ... ok          104 ms
test create_table_restrict        ... ok          197 ms

======================
 All 13 tests passed.
======================
~~~