### PR TITLE
Fixed erroneous restriction on CREATE MATERIALIZED VIEW.

### DIFF
--- a/src/tsurugi_utility/tsurugi_utility.c
+++ b/src/tsurugi_utility/tsurugi_utility.c
@@ -125,7 +125,11 @@ tsurugi_ProcessUtility(PlannedStmt *pstmt,
 		{
 			if (IsTsurugifdwInstalled())
 			{
-				elog(ERROR, "This database is for Tsurugi, so CREATE TABLE AS is not supported");
+				switch (((CreateTableAsStmt *) parsetree)->relkind)
+            	{
+                	case OBJECT_TABLE:
+						elog(ERROR, "This database is for Tsurugi, so CREATE TABLE AS is not supported");
+				}
 			}
 			standard_ProcessUtility(pstmt, queryString,context, params, queryEnv,
 									dest, completionTag);


### PR DESCRIPTION
Fixed erroneous restriction on CREATE MATERIALIZED VIEW.

```
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           29 ms
test create_table                 ... ok          112 ms
test create_index                 ... ok           69 ms
test insert_select_happy          ... ok          305 ms
test update_delete                ... ok          203 ms
test select_statements            ... ok          131 ms
test user_management              ... ok           22 ms
test udf_transaction              ... ok          471 ms
test prepare_statment             ... ok          412 ms
test prepare_select_statment      ... ok          157 ms
test prepare_decimal              ... ok          211 ms
test manual_tutorial              ... ok          102 ms
test create_table_restrict        ... ok          195 ms

======================
 All 13 tests passed. 
======================
```