### PR TITLE
Updated the document.

### DIFF
--- a/docs/appendixes.md
+++ b/docs/appendixes.md
@@ -10,6 +10,8 @@ PostgreSQLとTsurugiはアーキテクチャおよびその性質が異なるた
 
 - ORDER BY句のNULLSオプションのデフォルトがNULLS FIRSTとなります。PostgreSQLはNULLS LASTです。
 
+- SQLのINSERTコマンドに`insert-option`（OR REPLACE/OR IGNORE/IF NOT EXISTS）が指定できません。PostgreSQLは`insert-option`を指定することができません。
+
 - Tsurugiのデータ型とそれに対応するJDBC API(Java)およびPostgreSQLのデータ型は適切にマッピングする必要があります。※ PostgreSQL JDBDドライバは`TIME WITH TIME ZONE`型を[非サポート](https://jdbc.postgresql.org/documentation/query/#using-java-8-date-and-time-classes)としています。
 
     | Tsurugi | Java(JDBC) | PostgreSQL |
@@ -42,7 +44,12 @@ PostgreSQLとTsurugiはアーキテクチャおよびその性質が異なるた
 
 - Tsurugiのバイナリデータ型（BINARY/VARBINARY/BINARY VARYING）を操作することはできません。
 
-- SQLのPREPAREコマンドでプリペアするSELECT文にLIMIT句（結果行の一部分のみ返す）を使用することはできません。
+- SQLのPREPAREコマンドでプリペアするSQL文に以下を使用することはできません。
+  - SELECT文で指定可能な`set-quantifier`（ALL/DISTINCT）
+  - SELECT文で指定可能なLIMIT句
+  - SELECT文で指定可能な集約関数（UNION/EXCEPT/INTERSECT）
+  - INSERT文の`insert-source`で指定可能な`DEFAULT VALUES`
+  - INSERT文の`insert-source`で指定可能な`query-expression`
 
 ### サードパーティライセンス
 

--- a/src/tsurugi_utility/tsurugi_utility.c
+++ b/src/tsurugi_utility/tsurugi_utility.c
@@ -129,6 +129,9 @@ tsurugi_ProcessUtility(PlannedStmt *pstmt,
             	{
                 	case OBJECT_TABLE:
 						elog(ERROR, "This database is for Tsurugi, so CREATE TABLE AS is not supported");
+						break;
+					default:
+						break;
 				}
 			}
 			standard_ProcessUtility(pstmt, queryString,context, params, queryEnv,


### PR DESCRIPTION
Added limitations of PREPARE to the document.

~~~
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           32 ms
test create_table                 ... ok          109 ms
test create_index                 ... ok           70 ms
test insert_select_happy          ... ok          280 ms
test update_delete                ... ok          196 ms
test select_statements            ... ok          131 ms
test user_management              ... ok           21 ms
test udf_transaction              ... ok          488 ms
test prepare_statment             ... ok          401 ms
test prepare_select_statment      ... ok          168 ms
test prepare_decimal              ... ok          205 ms
test manual_tutorial              ... ok          104 ms
test create_table_restrict        ... ok          189 ms

======================
 All 13 tests passed.
======================
~~~