### PR TITLE
Removed some constraints from the PREPARE command.

### DIFF
--- a/docs/appendixes.md
+++ b/docs/appendixes.md
@@ -40,16 +40,10 @@ PostgreSQLとTsurugiはアーキテクチャおよびその性質が異なるた
 
 ### 制約事項
 
-現バージョンでは以下の機能を制限とします。
+現バージョン（Tsurugi 1.2.0とTsurugi FDWの組み合わせ環境）では以下の機能を制限とします。
 
-- Tsurugiのバイナリデータ型（BINARY/VARBINARY/BINARY VARYING）を操作することはできません。
-
-- SQLのPREPAREコマンドでプリペアするSQL文に以下を使用することはできません。
-  - SELECT文で指定可能な`set-quantifier`（ALL/DISTINCT）
-  - SELECT文で指定可能なLIMIT句
-  - SELECT文で指定可能な集約関数（UNION/EXCEPT/INTERSECT）
-  - INSERT文の`insert-source`で指定可能な`DEFAULT VALUES`
-  - INSERT文の`insert-source`で指定可能な`query-expression`
+- バイナリデータ型（BINARY/VARBINARY/BINARY VARYING）を操作することはできません。
+- SQLのPREPAREコマンドでプリペアするSQL文に集合演算子（UNION/EXCEPT/INTERSECT）があるとEXECUTEコマンドで正しい結果を得ることができません。
 
 ### サードパーティライセンス
 
@@ -88,3 +82,9 @@ Tsurugi FDWには、ライセンス規定または著作権の表示が必要な
 
 - 1.0.0
   - 初版
+- 1.1.0
+  - SQLのPREPAREコマンドで制約事項としていた以下のSQL構文の使用を解除
+    SELECT文で指定可能なset-quantifier（ALL/DISTINCT）
+    SELECT文で指定可能なLIMIT句
+    INSERT文のinsert-sourceで指定可能なDEFAULT VALUES
+    INSERT文のinsert-sourceで指定可能なquery-expression

--- a/expected/prepare_statment.out
+++ b/expected/prepare_statment.out
@@ -555,3 +555,206 @@ select * from trg_timestamptz order by id;
  10 | 2023-08-02 00:01:23.456789 | 2023-08-02 09:01:23.456789+09
 (10 rows)
 
+/************************/
+/* bug fix confirm r685 */
+/************************/
+select * from employee_1 order by id, name;
+ id | name  |  salary  
+----+-------+----------
+  1 | Alice | 50000.00
+  1 | Alice | 50000.00
+  1 | Alice | 50000.00
+  2 | Bob   | 55000.00
+  2 | Bob   | 55000.00
+  2 | Bob   | 55000.00
+ 11 | kf    | 50000.00
+ 11 | kf    | 50000.00
+ 12 | yy    | 55000.00
+ 12 | yy    | 55000.00
+(10 rows)
+
+select * from employee_2 order by id, name;
+ id |  name   |  salary  
+----+---------+----------
+  1 | Alice   | 50000.00
+  1 | Alice   | 50000.00
+  1 | Alice   | 50000.00
+  1 | Unknown | 30000.00
+  1 | Unknown | 30000.00
+  1 | Unknown | 30000.00
+  1 | Unknown | 30000.00
+  2 | Bob     | 55000.00
+  2 | Bob     | 55000.00
+  2 | Bob     | 55000.00
+  3 | Charile | 47000.00
+  3 | Charile | 47000.00
+  4 | David   | 48000.00
+  5 | Eva     | 50000.00
+  6 | Frank   | 52000.00
+  6 | Frank   | 52000.00
+  7 | Grace   | 53000.00
+(17 rows)
+
+/* limit r682 */
+PREPARE limit_5 AS select * from employee_2 order by id, name limit 5;
+EXECUTE limit_5;
+ id |  name   |  salary  
+----+---------+----------
+  1 | Alice   | 50000.00
+  1 | Alice   | 50000.00
+  1 | Alice   | 50000.00
+  1 | Unknown | 30000.00
+  1 | Unknown | 30000.00
+(5 rows)
+
+-- Error:SYNTAX_EXCEPTION
+PREPARE limit_all AS select * from employee_2 order by id, name limit all;
+ERROR:  Failed to prepare SQL statement to Tsurugi. (13)
+	sql:SELECT * FROM employee_2 ORDER BY id, name LIMIT ALL 
+Tsurugi Server Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"appeared unexpected token: "ALL", expected one of {(, +, -, ABS, AVG, ...}" region:"region(begin=49, end=52)")
+-- Error:TYPE_ANALYZE_EXCEPTION
+PREPARE limit_x (int) AS select * from employee_2 order by id, name limit $1;
+ERROR:  Failed to prepare SQL statement to Tsurugi. (13)
+	sql:SELECT * FROM employee_2 ORDER BY id, name LIMIT :LIMIT_1
+Tsurugi Server Error: TYPE_ANALYZE_EXCEPTION (SQL-03003: compile failed with error:invalid_unsigned_integer message:"must be a unsigned integer: variable_reference" location:<input>:1:50+8)
+/* set quantifier r686 */
+PREPARE quantifier_distinct AS select distinct * from employee_2 order by id, name;
+EXECUTE quantifier_distinct;
+ id |  name   |  salary  
+----+---------+----------
+  1 | Alice   | 50000.00
+  1 | Unknown | 30000.00
+  2 | Bob     | 55000.00
+  3 | Charile | 47000.00
+  4 | David   | 48000.00
+  5 | Eva     | 50000.00
+  6 | Frank   | 52000.00
+  7 | Grace   | 53000.00
+(8 rows)
+
+PREPARE quantifier_all AS select all * from employee_2 order by id, name;
+EXECUTE quantifier_all;
+ id |  name   |  salary  
+----+---------+----------
+  1 | Alice   | 50000.00
+  1 | Alice   | 50000.00
+  1 | Alice   | 50000.00
+  1 | Unknown | 30000.00
+  1 | Unknown | 30000.00
+  1 | Unknown | 30000.00
+  1 | Unknown | 30000.00
+  2 | Bob     | 55000.00
+  2 | Bob     | 55000.00
+  2 | Bob     | 55000.00
+  3 | Charile | 47000.00
+  3 | Charile | 47000.00
+  4 | David   | 48000.00
+  5 | Eva     | 50000.00
+  6 | Frank   | 52000.00
+  6 | Frank   | 52000.00
+  7 | Grace   | 53000.00
+(17 rows)
+
+/* set operators r687 */
+PREPARE uni AS select * from employee_1 union select * from employee_2 order by id, name;
+PREPARE uni_all AS select * from employee_1 union all select * from employee_2 order by id, name;
+PREPARE exce AS select * from employee_1 except select * from employee_2 order by id, name;
+-- Error:UNSUPPORTED_COMPILER_FEATURE_EXCEPTION
+PREPARE exce_all AS select * from employee_1 except all select * from employee_2 order by id, name;
+ERROR:  Failed to prepare SQL statement to Tsurugi. (13)
+	sql:SELECT * FROM employee_1 EXCEPT ALL SELECT * FROM employee_2 ORDER BY id, name
+Tsurugi Server Error: UNSUPPORTED_COMPILER_FEATURE_EXCEPTION (SQL-03010: compile failed with error:unsupported_feature message:"difference operator is unsupported" location:(unknown))
+PREPARE inte AS select * from employee_1 intersect select * from employee_2 order by id, name;
+-- Error:UNSUPPORTED_COMPILER_FEATURE_EXCEPTION
+PREPARE inte_all AS select * from employee_1 intersect all select * from employee_2 order by id, name;
+ERROR:  Failed to prepare SQL statement to Tsurugi. (13)
+	sql:SELECT * FROM employee_1 INTERSECT ALL SELECT * FROM employee_2 ORDER BY id, name
+Tsurugi Server Error: UNSUPPORTED_COMPILER_FEATURE_EXCEPTION (SQL-03010: compile failed with error:unsupported_feature message:"intersection operator is unsupported" location:(unknown))
+-- EXECUTE see:r711
+/* set operators r688 */
+select * from employee_i order by id, name;
+ id | name | salary 
+----+------+--------
+(0 rows)
+
+prepare ins_def as insert into employee_i default values;
+execute ins_def;
+select * from employee_i order by id, name;
+ id |  name   |  salary  
+----+---------+----------
+  1 | Unknown | 30000.00
+(1 row)
+
+select * from employee_1 where id < 10 order by id, name;
+ id | name  |  salary  
+----+-------+----------
+  1 | Alice | 50000.00
+  1 | Alice | 50000.00
+  1 | Alice | 50000.00
+  2 | Bob   | 55000.00
+  2 | Bob   | 55000.00
+  2 | Bob   | 55000.00
+(6 rows)
+
+prepare ins_query as insert into employee_i select * from employee_1 where id < 10 order by id, name;
+execute ins_query;
+select * from employee_i order by id, name;
+ id |  name   |  salary  
+----+---------+----------
+  1 | Alice   | 50000.00
+  1 | Alice   | 50000.00
+  1 | Alice   | 50000.00
+  1 | Unknown | 30000.00
+  2 | Bob     | 55000.00
+  2 | Bob     | 55000.00
+  2 | Bob     | 55000.00
+(7 rows)
+
+/* group by r707 */
+PREPARE group_name AS select id, count(name), sum(salary) from employee_2 group by id order by id;
+EXECUTE group_name;
+ id | count |    sum    
+----+-------+-----------
+  1 |     7 | 270000.00
+  2 |     3 | 165000.00
+  3 |     2 |  94000.00
+  4 |     1 |  48000.00
+  5 |     1 |  50000.00
+  6 |     2 | 104000.00
+  7 |     1 |  53000.00
+(7 rows)
+
+-- Error:UNSUPPORTED_COMPILER_FEATURE_EXCEPTION
+PREPARE group_num AS select id, count(name), sum(salary) from employee_2 group by 1 order by id;
+ERROR:  Failed to prepare SQL statement to Tsurugi. (13)
+	sql:SELECT id, count(name), sum(salary) FROM employee_2 GROUP BY 1  ORDER BY id
+Tsurugi Server Error: UNSUPPORTED_COMPILER_FEATURE_EXCEPTION (SQL-03010: compile failed with error:unsupported_feature message:"plain variable is required in GROUP BY clause" location:<input>:1:62+1)
+/* order by r708 */
+PREPARE order_name AS select * from employee_2 order by id, name;
+EXECUTE order_name;
+ id |  name   |  salary  
+----+---------+----------
+  1 | Alice   | 50000.00
+  1 | Alice   | 50000.00
+  1 | Alice   | 50000.00
+  1 | Unknown | 30000.00
+  1 | Unknown | 30000.00
+  1 | Unknown | 30000.00
+  1 | Unknown | 30000.00
+  2 | Bob     | 55000.00
+  2 | Bob     | 55000.00
+  2 | Bob     | 55000.00
+  3 | Charile | 47000.00
+  3 | Charile | 47000.00
+  4 | David   | 48000.00
+  5 | Eva     | 50000.00
+  6 | Frank   | 52000.00
+  6 | Frank   | 52000.00
+  7 | Grace   | 53000.00
+(17 rows)
+
+-- Error:UNSUPPORTED_COMPILER_FEATURE_EXCEPTION
+PREPARE order_num AS select * from employee_2 order by 1, 2;
+ERROR:  Failed to prepare SQL statement to Tsurugi. (13)
+	sql:SELECT * FROM employee_2 ORDER BY 1 , 2 
+Tsurugi Server Error: UNSUPPORTED_COMPILER_FEATURE_EXCEPTION (SQL-03010: compile failed with error:unsupported_feature message:"plain literal is not allowed in ORDER BY clause" location:<input>:1:35+1)

--- a/expected/test_preparation.out
+++ b/expected/test_preparation.out
@@ -172,3 +172,7 @@ CREATE FOREIGN TABLE weather (
     prcp            real,          -- 降水量
     the_date        date default '2023-04-01'
 ) SERVER tsurugidb;
+/* bug fix confirm */
+CREATE FOREIGN TABLE employee_1 (id INTEGER DEFAULT 1, name VARCHAR(100) DEFAULT 'Unknown', salary NUMERIC(10, 2) DEFAULT 30000.00) SERVER tsurugidb;
+CREATE FOREIGN TABLE employee_2 (id INTEGER DEFAULT 1, name VARCHAR(100) DEFAULT 'Unknown', salary NUMERIC(10, 2) DEFAULT 30000.00) SERVER tsurugidb;
+CREATE FOREIGN TABLE employee_i (id INTEGER DEFAULT 1, name VARCHAR(100) DEFAULT 'Unknown', salary NUMERIC(10, 2) DEFAULT 30000.00) SERVER tsurugidb;

--- a/scripts/create_tsurugi_tables.sql
+++ b/scripts/create_tsurugi_tables.sql
@@ -152,4 +152,26 @@ CREATE TABLE weather (
     the_date        date default DATE '2023-04-01'
 );
 
-
+/* bug fix confirm */
+CREATE TABLE employee_1 (id INTEGER DEFAULT 1, name VARCHAR(100) DEFAULT 'Unknown', salary NUMERIC(10, 2) DEFAULT 30000.00);
+CREATE TABLE employee_2 (id INTEGER DEFAULT 1, name VARCHAR(100) DEFAULT 'Unknown', salary NUMERIC(10, 2) DEFAULT 30000.00);
+CREATE TABLE employee_i (id INTEGER DEFAULT 1, name VARCHAR(100) DEFAULT 'Unknown', salary NUMERIC(10, 2) DEFAULT 30000.00);
+INSERT INTO employee_1 (id, name, salary) VALUES (1, 'Alice', 50000), (2, 'Bob', 55000);
+INSERT INTO employee_1 (id, name, salary) VALUES (11, 'kf', 50000), (12, 'yy', 55000);
+INSERT INTO employee_1 (id, name, salary) VALUES (1, 'Alice', 50000), (2, 'Bob', 55000);
+INSERT INTO employee_1 (id, name, salary) VALUES (11, 'kf', 50000), (12, 'yy', 55000);
+INSERT INTO employee_1 (id, name, salary) VALUES (1, 'Alice', 50000), (2, 'Bob', 55000);
+INSERT INTO employee_2 DEFAULT VALUES;
+INSERT INTO employee_2 DEFAULT VALUES;
+INSERT INTO employee_2 (id, name, salary) VALUES (1, 'Alice', 50000), (2, 'Bob', 55000);
+INSERT INTO employee_2 (id, name, salary) VALUES (1, 'Alice', 50000), (2, 'Bob', 55000);
+INSERT INTO employee_2 (id, name, salary) VALUES (3, 'Charile', 47000);
+INSERT INTO employee_2 (id, name, salary) VALUES (6, 'Frank', 52000);
+INSERT INTO employee_2 (id, name, salary) VALUES (7, 'Grace', 53000);
+INSERT INTO employee_2 DEFAULT VALUES;
+INSERT INTO employee_2 DEFAULT VALUES;
+INSERT INTO employee_2 (id, name, salary) VALUES (1, 'Alice', 50000), (2, 'Bob', 55000);
+INSERT INTO employee_2 (id, name, salary) VALUES (3, 'Charile', 47000);
+INSERT INTO employee_2 (id, name, salary) VALUES (4, 'David', 48000);
+INSERT INTO employee_2 (id, name, salary) VALUES (5, 'Eva', 50000);
+INSERT INTO employee_2 (id, name, salary) VALUES (6, 'Frank', 52000);

--- a/scripts/drop_tsurugi_tables.sql
+++ b/scripts/drop_tsurugi_tables.sql
@@ -66,3 +66,8 @@ DROP TABLE trg_numeric_s38;
 
 /* manual_tutorial.sql */
 DROP TABLE weather;
+
+/* bug fix confirm */
+DROP TABLE employee_1;
+DROP TABLE employee_2;
+DROP TABLE employee_i;

--- a/sql/test_preparation.sql
+++ b/sql/test_preparation.sql
@@ -200,3 +200,8 @@ CREATE FOREIGN TABLE weather (
     prcp            real,          -- 降水量
     the_date        date default '2023-04-01'
 ) SERVER tsurugidb;
+
+/* bug fix confirm */
+CREATE FOREIGN TABLE employee_1 (id INTEGER DEFAULT 1, name VARCHAR(100) DEFAULT 'Unknown', salary NUMERIC(10, 2) DEFAULT 30000.00) SERVER tsurugidb;
+CREATE FOREIGN TABLE employee_2 (id INTEGER DEFAULT 1, name VARCHAR(100) DEFAULT 'Unknown', salary NUMERIC(10, 2) DEFAULT 30000.00) SERVER tsurugidb;
+CREATE FOREIGN TABLE employee_i (id INTEGER DEFAULT 1, name VARCHAR(100) DEFAULT 'Unknown', salary NUMERIC(10, 2) DEFAULT 30000.00) SERVER tsurugidb;

--- a/src/tsurugi_fdw/tsurugi_fdw.cpp
+++ b/src/tsurugi_fdw/tsurugi_fdw.cpp
@@ -2008,6 +2008,12 @@ store_pg_data_type(tsurugiFdwState* fdw_state, List* tlist)
 				Var *var = (Var *) node;
 				data_types[i] = var->vartype;
 			}
+			else if (nodeTag(node) == T_Const)
+			{
+				// When generating placeholders in a SELECT query expression.
+				elog(DEBUG5, "Skip the data type placeholders. (index: %d, type:%u)",
+					 i, (unsigned int) nodeTag(node));
+			}
 			else
 			{
 				elog(ERROR, "Unexpected data type in target list. (index: %d, type:%u)",

--- a/src/tsurugi_utility/prepare_execute/prepare_execute.cpp
+++ b/src/tsurugi_utility/prepare_execute/prepare_execute.cpp
@@ -933,6 +933,25 @@ deparse_sort_clause(List* sortClause,
 }
 
 void
+deparse_limit_clause(Node* limitCount,
+					 const Oid* argtypes,
+					 stub::placeholders_type& placeholders,
+					 StringInfo buf)
+{
+	if (IsA(limitCount, A_Const)) {
+		A_Const* con = (A_Const *) limitCount;
+		Value* val = &con->val;
+		if IsA(val, Null) {
+			appendStringInfoString(buf, "ALL ");
+			return;
+		}
+	}
+
+	std::string name = "LIMIT";
+	deparse_expr_recurse(limitCount, argtypes, placeholders, name, buf);
+}
+
+void
 deparse_join_expr(JoinExpr* join,
 				  const Oid* argtypes,
 				  stub::placeholders_type& placeholders,
@@ -1217,8 +1236,7 @@ deparse_select_query(const SelectStmt* stmt,
 
 	if (stmt->limitCount != NULL) {
 		appendStringInfoString(buf, " LIMIT ");
-		std::string name = "LIMIT";
-		deparse_expr_recurse(stmt->limitCount, argtypes, placeholders, name, buf);
+		deparse_limit_clause(stmt->limitCount, argtypes, placeholders, buf);
 	}
 }
 

--- a/src/tsurugi_utility/prepare_execute/prepare_execute.cpp
+++ b/src/tsurugi_utility/prepare_execute/prepare_execute.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Project Tsurugi.
+ * Copyright 2023-2025 Project Tsurugi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +72,9 @@ bool deparse_expr_recurse(Node* expr, const Oid* argtypes, stub::placeholders_ty
 void deparse_execute_where_clause(const Node* expr, const ExecuteStmt* stmts);
 bool deparse_execute_expr_recurse(Node* expr, std::string& col_name, const ExecuteStmt* stmts);
 void deparse_select_query(const SelectStmt* stmt, const Oid* argtypes, stub::placeholders_type& placeholders, StringInfo buf);
+void deparse_select_operation_query(const SelectStmt* stmt, const Oid* argtypes, stub::placeholders_type& placeholders, StringInfo buf);
+void deparse_execute_select_query(const SelectStmt* stmt, const ExecuteStmt* stmts);
+void deparse_execute_select_operation_query(const SelectStmt* stmt, const ExecuteStmt* stmts);
 
 void
 get_tsurugi_table_join_expr(JoinExpr* join,
@@ -745,7 +748,12 @@ deparse_expr_recurse(Node* expr,
 			{
 				SubLink* sub_link = (SubLink *) expr;
 				appendStringInfoString(buf, "EXISTS (");
-				deparse_select_query((SelectStmt*) sub_link->subselect, argtypes, placeholders, buf);
+				SelectStmt* substmt = (SelectStmt *)sub_link->subselect;
+				if (substmt->op == SETOP_NONE) {
+					deparse_select_query(substmt, argtypes, placeholders, buf);
+				} else {
+					deparse_select_operation_query(substmt, argtypes, placeholders, buf);
+				}
 				appendStringInfoString(buf, ")");
 			}
 			break;
@@ -825,7 +833,12 @@ deparse_where_clause(Node* expr,
 			{
 				SubLink* sub_link = (SubLink *) expr;
 				appendStringInfoString(buf, "EXISTS (");
-				deparse_select_query((SelectStmt*) sub_link->subselect, argtypes, placeholders, buf);
+				SelectStmt* substmt = (SelectStmt *)sub_link->subselect;
+				if (substmt->op == SETOP_NONE) {
+					deparse_select_query(substmt, argtypes, placeholders, buf);
+				} else {
+					deparse_select_operation_query(substmt, argtypes, placeholders, buf);
+				}
 				appendStringInfoString(buf, ")");
 			}
 			break;
@@ -841,7 +854,27 @@ deparse_where_clause(Node* expr,
 }
 
 void
+deparse_group_clause(List* groupClause,
+					 const Oid* argtypes,
+					 stub::placeholders_type& placeholders,
+					 StringInfo buf)
+{
+	const char* sep = "";
+	ListCell* l;
+	foreach(l, groupClause)
+	{
+		Node* group = (Node *) lfirst(l);
+		appendStringInfoString(buf, sep);
+		std::string name = "GROUP";
+		deparse_expr_recurse(group, argtypes, placeholders, name, buf);
+		sep = ", ";
+	}
+}
+
+void
 deparse_sort_clause(List* sortClause,
+					 const Oid* argtypes,
+					 stub::placeholders_type& placeholders,
 					 StringInfo buf)
 {
 	const char* sep = "";
@@ -852,14 +885,8 @@ deparse_sort_clause(List* sortClause,
 		if (IsA(sort, SortBy)) {
 			SortBy* sortby = (SortBy *) sort;
 			appendStringInfoString(buf, sep);
-			if (IsA(sortby->node, ColumnRef)) {
-				deparse_column_ref((ColumnRef*) sortby->node, NULL, buf);
-			}
-			if (IsA(sortby->node, A_Const)) {
-				A_Const* con = (A_Const *) sortby->node;
-				Value* val = &con->val;
-				deparse_a_const(val, buf);
-			}
+			std::string name = "SORT";
+			deparse_expr_recurse(sortby->node, argtypes, placeholders, name, buf);
 			switch (sortby->sortby_dir)
 			{
 				case SORTBY_DEFAULT:
@@ -989,6 +1016,26 @@ deparse_join_expr(JoinExpr* join,
 	}
 }
 
+bool
+isGeneralSelect(const SelectStmt* selectStmt)
+{
+	/*
+	 * We have three cases to deal with: DEFAULT VALUES (selectStmt == NULL),
+	 * VALUES list, or general SELECT input.  We special-case VALUES, both for
+	 * efficiency and so we can handle DEFAULT specifications.
+	 *
+	 * The grammar allows attaching ORDER BY, LIMIT, FOR UPDATE, or WITH to a
+	 * VALUES clause.  If we have any of those, treat it as a general SELECT;
+	 * so it will work, but you can't use DEFAULT items together with those.
+	 */
+	return (selectStmt && (selectStmt->valuesLists == NIL ||
+						   selectStmt->sortClause != NIL ||
+						   selectStmt->limitOffset != NULL ||
+						   selectStmt->limitCount != NULL ||
+						   selectStmt->lockingClause != NIL ||
+						   selectStmt->withClause != NULL));
+}
+
 void
 deparse_insert_query(const InsertStmt* stmt,
 					 const Oid* argtypes,
@@ -999,12 +1046,23 @@ deparse_insert_query(const InsertStmt* stmt,
 
 	appendStringInfo(buf, "INSERT INTO %s ", stmt->relation->relname);
 
-	deparse_query_columns(stmt->cols, col_names, buf);
-
-	appendStringInfoString(buf, " VALUES ");
+	if (stmt->cols != NULL) {
+		deparse_query_columns(stmt->cols, col_names, buf);
+	}
 
 	SelectStmt* selectStmt = (SelectStmt *)stmt->selectStmt;
-	deparse_values_lists(selectStmt->valuesLists, argtypes, col_names, placeholders, buf);
+	if (selectStmt == NULL) {
+		appendStringInfoString(buf, " DEFAULT VALUES");
+	} else if (isGeneralSelect(selectStmt)) {
+		if (selectStmt->op == SETOP_NONE) {
+			deparse_select_query(selectStmt, argtypes, placeholders, buf);
+		} else {
+			deparse_select_operation_query(selectStmt, argtypes, placeholders, buf);
+		}
+	} else if (list_length(selectStmt->valuesLists)) {
+		appendStringInfoString(buf, " VALUES ");
+		deparse_values_lists(selectStmt->valuesLists, argtypes, col_names, placeholders, buf);
+	}
 }
 
 void
@@ -1063,6 +1121,20 @@ deparse_select_query(const SelectStmt* stmt,
 					 StringInfo buf)
 {
 	appendStringInfoString(buf, "SELECT ");
+
+	if (stmt->distinctClause == NIL)
+	{
+		// SELECT ALL retains all rows by default.
+		// appendStringInfoString(buf, "ALL ");
+	}
+	else if (linitial(stmt->distinctClause) == NULL)
+	{
+		appendStringInfoString(buf, "DISTINCT ");
+	}
+	else
+	{
+		elog(ERROR, "SELECT DISTINCT ON is not supported in Tsurugi.");
+	}
 
 	bool first = true;
 	ListCell* lc;
@@ -1130,14 +1202,7 @@ deparse_select_query(const SelectStmt* stmt,
 
 	if (stmt->groupClause != NULL) {
 		appendStringInfoString(buf, " GROUP BY ");
-		ListCell* l;
-		foreach(l, stmt->groupClause)
-		{
-			Node* group = (Node *) lfirst(l);
-			if (IsA(group, ColumnRef)) {
-				deparse_column_ref((ColumnRef*) group, NULL, buf);
-			}
-		}
+		deparse_group_clause(stmt->groupClause, argtypes, placeholders, buf);
 	}
 
 	if (stmt->havingClause != NULL) {
@@ -1147,7 +1212,68 @@ deparse_select_query(const SelectStmt* stmt,
 
 	if (stmt->sortClause != NULL) {
 		appendStringInfoString(buf, " ORDER BY ");
-		deparse_sort_clause(stmt->sortClause, buf);
+		deparse_sort_clause(stmt->sortClause, argtypes, placeholders, buf);
+	}
+
+	if (stmt->limitCount != NULL) {
+		appendStringInfoString(buf, " LIMIT ");
+		std::string name = "LIMIT";
+		deparse_expr_recurse(stmt->limitCount, argtypes, placeholders, name, buf);
+	}
+}
+
+void
+deparse_select_operation_query(const SelectStmt* stmt,
+							   const Oid* argtypes,
+							   stub::placeholders_type& placeholders,
+							   StringInfo buf)
+{
+	if (stmt->larg->op == SETOP_NONE)
+	{
+		deparse_select_query(stmt->larg, argtypes, placeholders, buf);
+	}
+	else
+	{
+		deparse_select_operation_query(stmt->larg, argtypes, placeholders, buf);
+	}
+
+	switch (stmt->op)
+	{
+		case SETOP_UNION:
+			appendStringInfoString(buf, " UNION ");
+			break;
+		case SETOP_INTERSECT:
+			appendStringInfoString(buf, " INTERSECT ");
+			break;
+		case SETOP_EXCEPT:
+			appendStringInfoString(buf, " EXCEPT ");
+			break;
+		default:
+			elog(ERROR, "unrecognized set op: %d", (int) stmt->op);
+	}
+	if (stmt->all)
+	{
+		appendStringInfoString(buf, "ALL ");
+	}
+
+	if (stmt->rarg->op == SETOP_NONE)
+	{
+		deparse_select_query(stmt->rarg, argtypes, placeholders, buf);
+	}
+	else
+	{
+		deparse_select_operation_query(stmt->rarg, argtypes, placeholders, buf);
+	}
+
+	if (stmt->sortClause != NULL) {
+		appendStringInfoString(buf, " ORDER BY ");
+		deparse_sort_clause(stmt->sortClause, argtypes, placeholders, buf);
+	}
+
+	if (stmt->limitCount != NULL) {
+		appendStringInfoString(buf, " LIMIT ");
+		std::string name = "LIMIT";
+		deparse_expr_recurse(stmt->limitCount, argtypes, placeholders, name, buf);
 	}
 }
 
@@ -1196,7 +1322,12 @@ after_prepare_stmt(const PrepareStmt* stmts,
 			break;
 		case T_SelectStmt:
 			{
-				deparse_select_query((SelectStmt *)query, argtypes, placeholders, &sql);
+				SelectStmt* stmt = (SelectStmt *)query;
+				if (stmt->op == SETOP_NONE) {
+					deparse_select_query(stmt, argtypes, placeholders, &sql);
+				} else {
+					deparse_select_operation_query(stmt, argtypes, placeholders, &sql);
+				}
 			}
 			break;
 		default:
@@ -1535,7 +1666,9 @@ deparse_execute_target_entry(const TargetEntry* target_entry,
 
 	if (IsA(expr, Param)) {
 		Param* target_param = (Param *) expr;
-		deparse_execute_param(stmts, target_param, target_entry->resname);
+		if (target_entry->resname) {
+			deparse_execute_param(stmts, target_param, target_entry->resname);
+		}
 	} else if (IsA(expr, FuncExpr)) {
 		FuncExpr* func_expr = (FuncExpr *) expr;
 		List* args = func_expr->args;
@@ -1816,8 +1949,12 @@ deparse_execute_expr_recurse(Node* expr,
 		case T_SubLink:
 			{
 				SubLink* sub_link = (SubLink *) expr;
-				SelectStmt* stmt = (SelectStmt *) sub_link->subselect;
-				deparse_execute_where_clause(stmt->whereClause, stmts);
+				SelectStmt* substmt = (SelectStmt *) sub_link->subselect;
+				if (substmt->op == SETOP_NONE) {
+					deparse_execute_select_query(substmt, stmts);
+				} else {
+					deparse_execute_select_operation_query(substmt, stmts);
+				}
 			}
 			break;
 
@@ -1878,8 +2015,12 @@ deparse_execute_where_clause(const Node* expr,
 		case T_SubLink:
 			{
 				SubLink* sub_link = (SubLink *) expr;
-				SelectStmt* stmt = (SelectStmt *) sub_link->subselect;
-				deparse_execute_where_clause(stmt->whereClause, stmts);
+				SelectStmt* substmt = (SelectStmt *) sub_link->subselect;
+				if (substmt->op == SETOP_NONE) {
+					deparse_execute_select_query(substmt, stmts);
+				} else {
+					deparse_execute_select_operation_query(substmt, stmts);
+				}
 			}
 			break;
 
@@ -1888,6 +2029,89 @@ deparse_execute_where_clause(const Node* expr,
 			elog(ERROR, "unrecognized where clause expr node type: %d", (int) nodeTag(expr));
 			break;
 	}
+}
+
+void
+deparse_execute_group_clause(List* groupClause,
+							 const ExecuteStmt* stmts)
+{
+	if (groupClause != NULL) {
+		ListCell* l;
+		foreach(l, groupClause)
+		{
+			Node* group = (Node *) lfirst(l);
+			std::string name = "GROUP";
+			deparse_execute_expr_recurse(group, name, stmts);
+		}
+	}
+}
+
+void
+deparse_execute_sort_clause(List* sortClause,
+							const ExecuteStmt* stmts)
+{
+	if (sortClause != NULL) {
+		ListCell* l;
+		foreach(l, sortClause)
+		{
+			Node* sort = (Node *) lfirst(l);
+			if (IsA(sort, SortBy)) {
+				SortBy* sortby = (SortBy *) sort;
+				std::string name = "SORT";
+				deparse_execute_expr_recurse(sortby->node, name, stmts);
+			}
+		}
+	}
+}
+
+void
+deparse_execute_limit_count(Node* limitCount,
+							const ExecuteStmt* stmts)
+{
+	if (limitCount != NULL) {
+		std::string name = "LIMIT";
+		deparse_execute_expr_recurse(limitCount, name, stmts);
+	}
+}
+
+void
+deparse_execute_select_query(const SelectStmt* stmt,
+							 const ExecuteStmt* stmts)
+{
+	if (stmt->fromClause != NULL) {
+		ListCell* l;
+		foreach(l, stmt->fromClause)
+		{
+			Node* from = (Node *) lfirst(l);
+			if (IsA(from, JoinExpr)) {
+				JoinExpr* join = (JoinExpr *) from;
+				deparse_execute_where_clause(join->quals, stmts);
+			}
+		}
+	}
+	deparse_execute_where_clause(stmt->whereClause, stmts);
+	deparse_execute_group_clause(stmt->groupClause, stmts);
+	deparse_execute_where_clause(stmt->havingClause, stmts);
+	deparse_execute_sort_clause(stmt->sortClause, stmts);
+	deparse_execute_limit_count(stmt->limitCount, stmts);
+}
+
+void
+deparse_execute_select_operation_query(const SelectStmt* stmt,
+									   const ExecuteStmt* stmts)
+{
+	if (stmt->larg->op == SETOP_NONE) {
+		deparse_execute_select_query(stmt->larg, stmts);
+	} else {
+		deparse_execute_select_operation_query(stmt->larg, stmts);
+	}
+	if (stmt->rarg->op == SETOP_NONE) {
+		deparse_execute_select_query(stmt->rarg, stmts);
+	} else {
+		deparse_execute_select_operation_query(stmt->rarg, stmts);
+	}
+	deparse_execute_sort_clause(stmt->sortClause, stmts);
+	deparse_execute_limit_count(stmt->limitCount, stmts);
 }
 
 Datum
@@ -2146,6 +2370,17 @@ befor_execute_stmt(const ExecuteStmt* stmts,
 	switch (nodeTag(raw_stmt->stmt))
 	{
 		case T_InsertStmt:
+			{
+				InsertStmt* stmt = (InsertStmt *) raw_stmt->stmt;
+				SelectStmt* selectStmt = (SelectStmt *)stmt->selectStmt;
+				if (isGeneralSelect(selectStmt)) {
+					if (selectStmt->op == SETOP_NONE) {
+						deparse_execute_select_query(selectStmt, stmts);
+					} else {
+						deparse_execute_select_operation_query(selectStmt, stmts);
+					}
+				}
+			}
 			break;
 		case T_UpdateStmt:
 			{
@@ -2162,20 +2397,11 @@ befor_execute_stmt(const ExecuteStmt* stmts,
 		case T_SelectStmt:
 			{
 				SelectStmt* stmt = (SelectStmt *) raw_stmt->stmt;
-
-				if (stmt->fromClause != NULL) {
-					ListCell* l;
-					foreach(l, stmt->fromClause)
-					{
-						Node* from = (Node *) lfirst(l);
-						if (IsA(from, JoinExpr)) {
-							JoinExpr* join = (JoinExpr *) from;
-							deparse_execute_where_clause(join->quals, stmts);
-						}
-					}
+				if (stmt->op == SETOP_NONE) {
+					deparse_execute_select_query(stmt, stmts);
+				} else {
+					deparse_execute_select_operation_query(stmt, stmts);
 				}
-				deparse_execute_where_clause(stmt->whereClause, stmts);
-				deparse_execute_where_clause(stmt->havingClause, stmts);
 			}
 			break;
 		default:


### PR DESCRIPTION
Removed constraints other than set operators from the PREPARE command.
- \<set-quantifier> (ALL/DISTINCT) for SELECT
- LIMIT clause for SELECT
- DEFAULT VALUES for INSERT
- \<query-expression> for INSERT

~~~log
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           30 ms
test create_table                 ... ok          112 ms
test create_index                 ... ok           91 ms
test insert_select_happy          ... ok          295 ms
test update_delete                ... ok          204 ms
test select_statements            ... ok          131 ms
test user_management              ... ok           21 ms
test udf_transaction              ... ok          457 ms
test prepare_statment             ... ok          464 ms
test prepare_select_statment      ... ok          163 ms
test prepare_decimal              ... ok          207 ms
test manual_tutorial              ... ok          112 ms
test create_table_restrict        ... ok          211 ms

======================
 All 13 tests passed.
======================
~~~