### PR TITLE
Change the error content (test expectations) of tsurugi-issues#896

### DIFF
--- a/expected/insert_select_happy.out
+++ b/expected/insert_select_happy.out
@@ -410,19 +410,19 @@ INSERT INTO trg_temporal_literal (id, tms_w_tz) VALUES (5, TIMESTAMP WITH TIME Z
 --- temporal_literal(auto cast) : tsurugi-issues#896  -- error
 INSERT INTO trg_temporal_literal (id, dt) VALUES (11, '2024-08-30');  -- error
 ERROR:  Failed to execute statement to Tsurugi. (13)
-Tsurugi Server Error: VALUE_EVALUATION_EXCEPTION (SQL-02011: An error occurred in evaluating values. error:unsupported)
+Tsurugi Server Error: UNSUPPORTED_RUNTIME_FEATURE_EXCEPTION (SQL-02050: unsupported expression)
 INSERT INTO trg_temporal_literal (id, tm) VALUES (12, '04:05:06.789');  -- error
 ERROR:  Failed to execute statement to Tsurugi. (13)
-Tsurugi Server Error: VALUE_EVALUATION_EXCEPTION (SQL-02011: An error occurred in evaluating values. error:unsupported)
+Tsurugi Server Error: UNSUPPORTED_RUNTIME_FEATURE_EXCEPTION (SQL-02050: unsupported expression)
 INSERT INTO trg_temporal_literal (id, tms) VALUES (13, '2024-08-30 04:05:06.789');  -- error
 ERROR:  Failed to execute statement to Tsurugi. (13)
-Tsurugi Server Error: VALUE_EVALUATION_EXCEPTION (SQL-02011: An error occurred in evaluating values. error:unsupported)
+Tsurugi Server Error: UNSUPPORTED_RUNTIME_FEATURE_EXCEPTION (SQL-02050: unsupported expression)
 INSERT INTO trg_temporal_literal (id, tms_wo_tz) VALUES (14, '2024-08-30 04:05:06.789');  -- error
 ERROR:  Failed to execute statement to Tsurugi. (13)
-Tsurugi Server Error: VALUE_EVALUATION_EXCEPTION (SQL-02011: An error occurred in evaluating values. error:unsupported)
+Tsurugi Server Error: UNSUPPORTED_RUNTIME_FEATURE_EXCEPTION (SQL-02050: unsupported expression)
 INSERT INTO trg_temporal_literal (id, tms_w_tz) VALUES (15, '2024-08-30 04:05:06.789+9:00');  -- error
 ERROR:  Failed to execute statement to Tsurugi. (13)
-Tsurugi Server Error: VALUE_EVALUATION_EXCEPTION (SQL-02011: An error occurred in evaluating values. error:unsupported)
+Tsurugi Server Error: UNSUPPORTED_RUNTIME_FEATURE_EXCEPTION (SQL-02050: unsupported expression)
 /* check timestamp with time zone in UTC */
 set session timezone to 'UTC';
 SELECT * FROM trg_temporal_literal ORDER BY id;


### PR DESCRIPTION
Change the error content (test expectations) of tsurugi-issues#896 from tsurugi 1.3.0.
https://github.com/project-tsurugi/tsurugi-issues/issues/896#issuecomment-2713625566

~~~
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           51 ms
test create_table                 ... ok          112 ms
test create_index                 ... ok           68 ms
test insert_select_happy          ... ok          308 ms
test update_delete                ... ok          202 ms
test select_statements            ... ok          133 ms
test user_management              ... ok           19 ms
test udf_transaction              ... ok          517 ms
test prepare_statment             ... ok          477 ms
test prepare_select_statment      ... ok          164 ms
test prepare_decimal              ... ok          207 ms
test manual_tutorial              ... ok          104 ms
test create_table_restrict        ... ok          215 ms

======================
 All 13 tests passed.
======================
~~~