### PR TITLE
Disable the LIKE clause tests due to ongoing implementation.

### DIFF
--- a/expected/prepare_select_statment.out
+++ b/expected/prepare_select_statment.out
@@ -56,12 +56,9 @@ PREPARE select_t1_where5
 PREPARE select_t2_where6
 	AS SELECT * FROM t2_prepare_select_statement WHERE c4 BETWEEN 2.2 AND 5.5 ORDER BY c1;
 -- WHERE #7
-/* tsurugi-issue#103 (no longer supports) */
-PREPARE select_t1_where7
-	AS SELECT * FROM t1_prepare_select_statement WHERE c7 LIKE '%LMN%' ORDER BY c1;
-ERROR:  Failed to prepare SQL statement to Tsurugi. (13)
-	sql:SELECT * FROM t1_prepare_select_statement WHERE c7 LIKE '%LMN%'  ORDER BY c1
-Tsurugi Server Error: UNSUPPORTED_COMPILER_FEATURE_EXCEPTION (SQL-03010: compile failed with error:unsupported_feature message:"unsupported scalar expression: {"node_kind":"pattern_match_predicate","match_value":{"node_kind":"variable_reference","name":{"node_kind":"simple","identifier":"c7","identifier_kind":"regular"}},"is_not":false,"operator_kind":"like","pattern":{"node_kind":"literal_expression","value":{"node_kind":"character_string","value":"'%LMN%'","concatenations":[]}}}" location:<input>:1:49+15)
+/* tsurugi-issue#1078 (disable due to development) */
+/* PREPARE select_t1_where7
+	AS SELECT * FROM t1_prepare_select_statement WHERE c7 LIKE '%LMN%' ORDER BY c1;*/
 -- WHERE #8
 /* not support EXISTS failed. (10) */
 PREPARE select_t1_where8
@@ -283,9 +280,8 @@ EXECUTE select_t2_where6;
 (3 rows)
 
 -- WHERE #7
-/* tsurugi-issue#103 (no longer supports) */
-EXECUTE select_t1_where7;
-ERROR:  prepared statement "select_t1_where7" does not exist
+/* tsurugi-issue#1078 (disable due to development) */
+/* EXECUTE select_t1_where7;*/
 -- WHERE #8
 /* not support EXISTS failed. (10)
 EXECUTE select_t1_where8;

--- a/expected/select_statements.out
+++ b/expected/select_statements.out
@@ -275,16 +275,15 @@ ORDER BY
 (3 rows)
 
 -- WHERE #7
-SELECT
+/* tsurugi-issue#1078 (disable due to development) */
+/*SELECT
     *
 FROM
     t1_select_statement
 WHERE
     c7 LIKE '%LMN%'
 ORDER BY 
-    c1;
-ERROR:  Failed to execute query to Tsurugi. (13)
-Tsurugi Server Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"unrecognized character: "~"" region:"region(begin=70, end=71)")
+    c1;*/
 -- WHERE #8
 /*
 SELECT

--- a/sql/prepare_select_statment.sql
+++ b/sql/prepare_select_statment.sql
@@ -54,9 +54,9 @@ PREPARE select_t1_where5
 PREPARE select_t2_where6
 	AS SELECT * FROM t2_prepare_select_statement WHERE c4 BETWEEN 2.2 AND 5.5 ORDER BY c1;
 -- WHERE #7
-/* tsurugi-issue#103 (no longer supports) */
-PREPARE select_t1_where7
-	AS SELECT * FROM t1_prepare_select_statement WHERE c7 LIKE '%LMN%' ORDER BY c1;
+/* tsurugi-issue#1078 (disable due to development) */
+/* PREPARE select_t1_where7
+	AS SELECT * FROM t1_prepare_select_statement WHERE c7 LIKE '%LMN%' ORDER BY c1;*/
 -- WHERE #8
 /* not support EXISTS failed. (10) */
 PREPARE select_t1_where8
@@ -155,8 +155,8 @@ EXECUTE select_t1_where5;
 /* tsurugi-issue#69 */
 EXECUTE select_t2_where6;
 -- WHERE #7
-/* tsurugi-issue#103 (no longer supports) */
-EXECUTE select_t1_where7;
+/* tsurugi-issue#1078 (disable due to development) */
+/* EXECUTE select_t1_where7;*/
 -- WHERE #8
 /* not support EXISTS failed. (10)
 EXECUTE select_t1_where8;

--- a/sql/select_statements.sql
+++ b/sql/select_statements.sql
@@ -162,14 +162,15 @@ ORDER BY
     c1;
 
 -- WHERE #7
-SELECT
+/* tsurugi-issue#1078 (disable due to development) */
+/*SELECT
     *
 FROM
     t1_select_statement
 WHERE
     c7 LIKE '%LMN%'
 ORDER BY 
-    c1;
+    c1;*/
 
 -- WHERE #8
 /*


### PR DESCRIPTION
Disable the LIKE clause tests due to ongoing implementation.
https://github.com/project-tsurugi/tsurugi-issues/issues/1078
https://github.com/project-tsurugi/eisen/issues/10

~~~log
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           31 ms
test create_table                 ... ok          111 ms
test create_index                 ... ok           69 ms
test insert_select_happy          ... ok          290 ms
test update_delete                ... ok          196 ms
test select_statements            ... ok          130 ms
test user_management              ... ok           20 ms
test udf_transaction              ... ok          513 ms
test prepare_statment             ... ok          482 ms
test prepare_select_statment      ... ok          163 ms
test prepare_decimal              ... ok          208 ms
test manual_tutorial              ... ok          101 ms
test create_table_restrict        ... ok          201 ms

======================
 All 13 tests passed.
======================
~~~