### PR TITLE
Fix a unused function.

### DIFF
--- a/src/tsurugi_fdw/tsurugi_fdw.cpp
+++ b/src/tsurugi_fdw/tsurugi_fdw.cpp
@@ -1207,8 +1207,6 @@ tsurugiBeginForeignScan(ForeignScanState* node, int eflags)
 	table = GetForeignTable(rte->relid);
 	server = GetForeignServer(table->serverid);
 
-	store_pg_data_type(fdw_state, fsplan->scan.plan.targetlist);
-
 	fdw_state->query_string = strVal(list_nth(fsplan->fdw_private,
 									 FdwScanPrivateSelectSql));
     fdw_state->retrieved_attrs = (List*) list_nth(fsplan->fdw_private, 
@@ -1986,7 +1984,7 @@ free_fdwstate(tsurugiFdwState* fdw_state)
  * 	This function was prepared because we decided that it would be better to
  * 	understand PostgreSQL data types.
  */
-static void 
+[[maybe_unused]] static void 
 store_pg_data_type(tsurugiFdwState* fdw_state, List* tlist)
 {
 	ListCell* lc;


### PR DESCRIPTION
Fix for #192 .

```bash
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           44 ms
test create_table                 ... ok          113 ms
test create_index                 ... ok           68 ms
test insert_select_happy          ... ok          285 ms
test update_delete                ... ok          199 ms
test select_statements            ... ok          129 ms
test user_management              ... ok           18 ms
test udf_transaction              ... ok          472 ms
test prepare_statment             ... ok          452 ms
test prepare_select_statment      ... ok          153 ms
test prepare_decimal              ... ok          226 ms
test manual_tutorial              ... ok          104 ms
test create_table_restrict        ... ok          207 ms

======================
 All 13 tests passed. 
======================
```