### PR TITLE
Feature/tsurugi planner

### DIFF
--- a/expected/prepare_statment.out
+++ b/expected/prepare_statment.out
@@ -710,6 +710,29 @@ select * from employee_i order by id, name;
   2 | Bob     | 55000.00
 (7 rows)
 
+PREPARE pre_emp2 AS select id, name, salary from employee_2 order by id;
+EXECUTE pre_emp2;
+ id |  name   |  salary  
+----+---------+----------
+  1 | Unknown | 30000.00
+  1 | Alice   | 50000.00
+  1 | Alice   | 50000.00
+  1 | Unknown | 30000.00
+  1 | Unknown | 30000.00
+  1 | Unknown | 30000.00
+  1 | Alice   | 50000.00
+  2 | Bob     | 55000.00
+  2 | Bob     | 55000.00
+  2 | Bob     | 55000.00
+  3 | Charile | 47000.00
+  3 | Charile | 47000.00
+  4 | David   | 48000.00
+  5 | Eva     | 50000.00
+  6 | Frank   | 52000.00
+  6 | Frank   | 52000.00
+  7 | Grace   | 53000.00
+(17 rows)
+
 /* group by r707 */
 PREPARE group_name AS select id, count(name), sum(salary) from employee_2 group by id order by id;
 EXECUTE group_name;

--- a/expected/select_statements.out
+++ b/expected/select_statements.out
@@ -142,15 +142,8 @@ FROM
     t2_select_statement
 ORDER BY 
     6;
- c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
-----+----+-----+-----+------+------------+-----
-  4 |    |     |     |      | NULL       | 
-  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
-  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
-  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
-  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
-(5 rows)
-
+ERROR:  Failed to execute query to Tsurugi. (13)
+Tsurugi Server Error: UNSUPPORTED_COMPILER_FEATURE_EXCEPTION (SQL-03010: compile failed with error:unsupported_feature message:"plain literal is not allowed in ORDER BY clause" location:<input>:6:5+1)
 -- ORDER BY #3
 SELECT
     c1, c4, c5, c6, c7
@@ -275,6 +268,7 @@ ORDER BY
 (3 rows)
 
 -- WHERE #7
+/* Tsurugi does not yet support "LIKE" cluase.
 SELECT
     *
 FROM
@@ -283,8 +277,7 @@ WHERE
     c7 LIKE '%LMN%'
 ORDER BY 
     c1;
-ERROR:  Failed to execute query to Tsurugi. (13)
-Tsurugi Server Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"unrecognized character: "~"" region:"region(begin=70, end=71)")
+*/
 -- WHERE #8
 /*
 SELECT
@@ -303,8 +296,10 @@ WHERE
     c4 IN (1.1,3.3)
 ORDER BY
     c4;
-ERROR:  Failed to execute query to Tsurugi. (13)
-Tsurugi Server Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"appeared unexpected token: "'{1.1,3.3}'", expected one of {SELECT, TABLE}" region:"region(begin=77, end=88)")
+ c1 | c2 | c3 | c4 | c5 | c6 | c7 
+----+----+----+----+----+----+----
+(0 rows)
+
 -- GROUP BY #1
 SELECT
     count(c1) AS "count(c1)", sum(c2) AS "sum(c2)", c7
@@ -356,26 +351,38 @@ WHERE
     b.c1 > 1
 ORDER BY
     a.c1;
-ERROR:  Failed to execute query to Tsurugi. (13)
-Tsurugi Server Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"appeared unexpected token: "t1_select_statement", expected one of {(, SELECT, TABLE, VALUES}" region:"region(begin=110, end=129)")
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             | c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+----------------------------+----+----+-----+-----+------+------------+-----
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+(2 rows)
+
 -- TG JOIN #2 /* tsurugi-issue#863 */
 SELECT 
-    a.c1, a.c2, b.c1, b.c7
+--  tsurugi-issue
+--  a.c1, a.c2, b.c1, b.c7
+    a.c1, a.c2, b.c2, b.c7
 FROM 
     t1_select_statement a INNER JOIN t2_select_statement b USING (c1)
 ORDER BY
     b.c4 DESC;   
-ERROR:  Failed to execute query to Tsurugi. (13)
-Tsurugi Server Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"appeared unexpected token: "t1_select_statement", expected one of {(, SELECT, TABLE, VALUES}" region:"region(begin=47, end=66)")
+ c1 | c2 | c2 | c7  
+----+----+----+-----
+  3 | 33 | 33 | ABC
+  2 | 22 | 22 | XYZ
+  1 | 11 | 11 | ABC
+(3 rows)
+
 -- TG JOIN #3 /* tsurugi-issue#863 */
 SELECT 
     a.c1, a.c3, b.c1, b.c6
 FROM 
+--  PostgreSQL specific syntax (!=)
     t1_select_statement a INNER JOIN t2_select_statement b ON a.c1 != b.c1
 ORDER BY
     a.c1;
 ERROR:  Failed to execute query to Tsurugi. (13)
-Tsurugi Server Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"appeared unexpected token: "t1_select_statement", expected one of {(, SELECT, TABLE, VALUES}" region:"region(begin=40, end=59)")
+Tsurugi Server Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"unrecognized character: "!"" region:"region(begin=109, end=110)")
 -- POSTGRESQL TABLE JOIN
 -- TG /* tsurugi-issue#863 */
 SELECT
@@ -384,8 +391,11 @@ FROM
     t1_select_statement AS a JOIN t2_select_statement AS b ON a.c4=b.c4 JOIN t1_select_statement AS c ON b.c4=c.c4
 WHERE
     a.c2=22;
-ERROR:  Failed to execute query to Tsurugi. (13)
-Tsurugi Server Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"appeared unexpected token: "t1_select_statement", expected one of {(, SELECT, TABLE}" region:"region(begin=160, end=179)")
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             | c1 | c2 | c3  | c4  |  c5  |     c6     | c7  | c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             
+----+----+-----+-----+------+------------+----------------------------+----+----+-----+-----+------+------------+-----+----+----+-----+-----+------+------------+----------------------------
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ |  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(1 row)
+
 -- TG /* tsurugi-issue#863 */
 SELECT
     *
@@ -393,8 +403,25 @@ FROM
     t1_select_statement AS a CROSS JOIN t2_select_statement AS b
 ORDER BY
     b.c1;
-ERROR:  Failed to execute query to Tsurugi. (13)
-Tsurugi Server Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"appeared unexpected token: "t1_select_statement", expected one of {(, SELECT, TABLE, VALUES}" region:"region(begin=110, end=129)")
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             | c1 | c2 | c3  | c4  |  c5  |     c6     | c7  
+----+----+-----+-----+------+------------+----------------------------+----+----+-----+-----+------+------------+-----
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  1 | 11 | 111 | 1.1 | 1.11 | one        | ABC
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | two        | XYZ
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | three      | ABC
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  4 |    |     |     |      | NULL       | 
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  4 |    |     |     |      | NULL       | 
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  4 |    |     |     |      | NULL       | 
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  5 | 55 | 555 | 5.5 | 5.55 | five       | XYZ
+(15 rows)
+
 -- TG /* tsurugi-issue#863 */
 SELECT
     *
@@ -402,5 +429,10 @@ FROM
     t1_select_statement AS a JOIN t1_select_statement AS b ON a.c3=b.c3
 ORDER BY
     a.c3;
-ERROR:  Failed to execute query to Tsurugi. (13)
-Tsurugi Server Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"appeared unexpected token: "t1_select_statement", expected one of {(, SELECT, TABLE, VALUES}" region:"region(begin=110, end=129)")
+ c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             | c1 | c2 | c3  | c4  |  c5  |     c6     |             c7             
+----+----+-----+-----+------+------------+----------------------------+----+----+-----+-----+------+------------+----------------------------
+  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  1 | 11 | 111 | 1.1 | 1.11 | first      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  2 | 22 | 222 | 2.2 | 2.22 | second     | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ |  3 | 33 | 333 | 3.3 | 3.33 | third      | ABCDEFGHIJKLMNOPQRSTUVWXYZ
+(3 rows)
+

--- a/include/tsurugi_fdw.h
+++ b/include/tsurugi_fdw.h
@@ -32,6 +32,9 @@ extern "C" {
 #include "nodes/plannodes.h"
 #include "utils/relcache.h"
 
+/* Planning Flag */
+#define __TSURUGI_PLANNER__
+
 /*
  * Note: Diverted from postgres_fdw
  */

--- a/sql/prepare_statment.sql
+++ b/sql/prepare_statment.sql
@@ -254,6 +254,9 @@ prepare ins_query as insert into employee_i select * from employee_1 where id < 
 execute ins_query;
 select * from employee_i order by id, name;
 
+PREPARE pre_emp2 AS select id, name, salary from employee_2 order by id;
+EXECUTE pre_emp2;
+
 /* group by r707 */
 PREPARE group_name AS select id, count(name), sum(salary) from employee_2 group by id order by id;
 EXECUTE group_name;

--- a/sql/select_statements.sql
+++ b/sql/select_statements.sql
@@ -162,6 +162,7 @@ ORDER BY
     c1;
 
 -- WHERE #7
+/* Tsurugi does not yet support "LIKE" cluase.
 SELECT
     *
 FROM
@@ -170,7 +171,7 @@ WHERE
     c7 LIKE '%LMN%'
 ORDER BY 
     c1;
-
+*/
 -- WHERE #8
 /*
 SELECT
@@ -234,7 +235,9 @@ ORDER BY
 
 -- TG JOIN #2 /* tsurugi-issue#863 */
 SELECT 
-    a.c1, a.c2, b.c1, b.c7
+--  tsurugi-issue
+--  a.c1, a.c2, b.c1, b.c7
+    a.c1, a.c2, b.c2, b.c7
 FROM 
     t1_select_statement a INNER JOIN t2_select_statement b USING (c1)
 ORDER BY
@@ -244,6 +247,7 @@ ORDER BY
 SELECT 
     a.c1, a.c3, b.c1, b.c6
 FROM 
+--  PostgreSQL specific syntax (!=)
     t1_select_statement a INNER JOIN t2_select_statement b ON a.c1 != b.c1
 ORDER BY
     a.c1;

--- a/src/common/init.c
+++ b/src/common/init.c
@@ -27,14 +27,14 @@ extern PGDLLIMPORT planner_hook_type planner_hook;
 extern PGDLLIMPORT ProcessUtility_hook_type ProcessUtility_hook;
 extern void _PG_init(void);
 #if PG_VERSION_NUM >= 130000
-extern PlannedStmt *alt_planner(Query *parse2, const char *query_string, int cursorOptions, ParamListInfo boundParams);
+extern PlannedStmt *tsurugi_planner(Query *parse2, const char *query_string, int cursorOptions, ParamListInfo boundParams);
 extern void tsurugi_ProcessUtility(PlannedStmt *pstmt,
                                    const char *query_string, ProcessUtilityContext context,
                                    ParamListInfo params,
                                    QueryEnvironment *queryEnv,
                                    DestReceiver *dest, QueryCompletion *qc);
 #else
-extern PlannedStmt *alt_planner(Query *parse2, int cursorOptions, ParamListInfo boundParams);
+extern PlannedStmt *tsurugi_planner(Query *parse2, int cursorOptions, ParamListInfo boundParams);
 extern void tsurugi_ProcessUtility(PlannedStmt *pstmt, 
                             	   const char *query_string, ProcessUtilityContext context, 
                             	   ParamListInfo params, 
@@ -46,7 +46,7 @@ void
 _PG_init(void)
 {
 #ifdef __TSURUGI_PLANNER__
-  	planner_hook = alt_planner;
+  	planner_hook = tsurugi_planner;
 #else
 	planner_hook = NULL;
 #endif

--- a/src/common/init.c
+++ b/src/common/init.c
@@ -21,6 +21,7 @@
 #include "postgres.h"
 #include "optimizer/planner.h"
 #include "tcop/utility.h"
+#include "tsurugi_fdw.h"
 
 extern PGDLLIMPORT planner_hook_type planner_hook;
 extern PGDLLIMPORT ProcessUtility_hook_type ProcessUtility_hook;
@@ -44,6 +45,10 @@ extern void tsurugi_ProcessUtility(PlannedStmt *pstmt,
 void
 _PG_init(void)
 {
-  planner_hook = alt_planner;
+#ifdef __TSURUGI_PLANNER__
+  	planner_hook = alt_planner;
+#else
+	planner_hook = NULL;
+#endif
   ProcessUtility_hook = tsurugi_ProcessUtility;
 }

--- a/src/tsurugi_fdw/tsurugi_fdw.cpp
+++ b/src/tsurugi_fdw/tsurugi_fdw.cpp
@@ -218,9 +218,7 @@ enum FdwPathPrivateIndex
 #ifdef __cplusplus
 extern "C" {
 #endif
-/*
- * SQL functions
- */
+
 PG_FUNCTION_INFO_V1(tsurugi_fdw_handler);
 
 /*
@@ -387,7 +385,9 @@ tsurugi_fdw_handler(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(routine);
 }
 
-/* FDW Plan functions */
+/*
+ * FDW Scan functions. 
+ */
 
 /*
  * tsurugiGetForeignRelSize
@@ -1165,10 +1165,6 @@ tsurugiGetForeignJoinPaths(PlannerInfo *root,
 	/* XXX Consider parameterized paths for the join relation */
 }                            
 
-/* 
- * 	fdw executor functions 
- */
-
 /*
  *  tsurugiBeginForeignScan
  *	    Preparation for scanning foreign tables.
@@ -1341,6 +1337,10 @@ tsurugiEndForeignScan(ForeignScanState* node)
 		free_fdw_state(fdw_state);
     }
 }
+
+/*
+ * FDW Update functions.
+ */
 
 /*
  * tsurugiBeginDirectModify
@@ -1856,6 +1856,10 @@ tsurugiEndForeignInsert(EState *estate,
 }
 
 /*
+ * FDW Explain functions.
+ */
+
+/*
  * tsurugiExplainForeignScan
  *		Produce extra output for EXPLAIN of a ForeignScan on a foreign table
  */
@@ -1915,6 +1919,10 @@ tsurugiAnalyzeForeignTable(Relation relation,
 
 	return true;
 }
+
+/*
+ * FDW Import Foreign Schema functions.
+ */
 
 /*
  *	@note	Not in use.

--- a/src/tsurugi_fdw/tsurugi_prepare.cpp
+++ b/src/tsurugi_fdw/tsurugi_prepare.cpp
@@ -80,6 +80,8 @@ begin_prepare_processing(const EState* estate)
 {
 	ParamListInfo params = estate->es_param_list_info;
 
+	elog(DEBUG2, "tsurugi_fdw : %s", __func__);
+
 	if (params == NULL) {
 		// If there is no parameter information, do nothing.
 		return;
@@ -446,6 +448,8 @@ void
 end_prepare_processing(const EState* estate)
 {
 	ParamListInfo params = estate->es_param_list_info;
+
+	elog(DEBUG2, "tsurugi_fdw : %s", __func__);
 
 	if (params == NULL) {
 		// If there is no parameter information, do nothing.

--- a/src/tsurugi_fdw/tsurugi_utils.cpp
+++ b/src/tsurugi_fdw/tsurugi_utils.cpp
@@ -43,7 +43,7 @@ std::string make_tsurugi_query(std::string_view query_string)
 {
     std::string tsurugi_query(query_string);
 
-	elog(DEBUG1, "tsurugi_fdw : raw query string : \"%s\"", query_string.data());
+	elog(DEBUG1, "tsurugi_fdw : input query string : \"%s\"", query_string.data());
 
 	// erase public schema.
 	std::smatch regex_match;
@@ -66,7 +66,7 @@ std::string make_tsurugi_query(std::string_view query_string)
         tsurugi_query.pop_back();
     }
 
-    elog(DEBUG1, "tsurugi_fdw : tsurugi query string : \"%s\"", tsurugi_query.c_str());
+    elog(DEBUG1, "tsurugi_fdw : remote query string : \"%s\"", tsurugi_query.c_str());
 
     return tsurugi_query;
 }

--- a/src/tsurugi_planner/tsurugi_planner.c
+++ b/src/tsurugi_planner/tsurugi_planner.c
@@ -16,7 +16,7 @@
  * Portions Copyright (c) 1996-2023, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, The Regents of the University of California
  *
- * alt_planner.c
+ * tsurugi_planner.c
  * Planning to push down DML for Tsurugi table to Tsurugi server
  */
 
@@ -35,7 +35,7 @@
 #include "parser/parse_coerce.h"
 #include "utils/rel.h"
 
-typedef struct alt_planner_info_
+typedef struct tsurugi_planner_info_
 {
 	Query	*parse;
 	bool	hasjoin;
@@ -56,9 +56,9 @@ PG_MODULE_MAGIC;
 
 /* planner_hook function */
 #if PG_VERSION_NUM >= 130000
-PlannedStmt *alt_planner(Query *parse2, const char *query_string, int cursorOptions, ParamListInfo boundParams);
+PlannedStmt *tsurugi_planner(Query *parse2, const char *query_string, int cursorOptions, ParamListInfo boundParams);
 #else
-PlannedStmt *alt_planner(Query *parse2, int cursorOptions, ParamListInfo boundParams);
+PlannedStmt *tsurugi_planner(Query *parse2, int cursorOptions, ParamListInfo boundParams);
 #endif
 static bool is_only_foreign_table(TsurugiPlannerInfo *root, List *rtable);
 static TsurugiPlannerInfo *init_TsurugiPlannerInfo(Query *parse);
@@ -71,7 +71,7 @@ static List *expand_targetlist(List *tlist, int command_type, Index result_relat
 static bool contain_foreign_tables(TsurugiPlannerInfo *root, List *rtable);
 
 /*
- * alt_planner
+ * tsurugi_planner
  *
  * input
  * Query *parse2             ...
@@ -83,9 +83,9 @@ static bool contain_foreign_tables(TsurugiPlannerInfo *root, List *rtable);
  */
 struct PlannedStmt *
 #if PG_VERSION_NUM >= 130000
-alt_planner(Query *parse2, const char *query_string, int cursorOptions, ParamListInfo boundParams)
+tsurugi_planner(Query *parse2, const char *query_string, int cursorOptions, ParamListInfo boundParams)
 #else
-alt_planner(Query *parse2, int cursorOptions, ParamListInfo boundParams)
+tsurugi_planner(Query *parse2, int cursorOptions, ParamListInfo boundParams)
 #endif
 {
 	Query *parse = copyObject(parse2);


### PR DESCRIPTION
- FDW planning process is changed to tsurugi_planner.

```
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           41 ms
test create_table                 ... ok          116 ms
test create_index                 ... ok           71 ms
test insert_select_happy          ... ok          281 ms
test update_delete                ... ok          205 ms
test select_statements            ... ok          160 ms
test user_management              ... ok           25 ms
test udf_transaction              ... ok          511 ms
test prepare_statment             ... ok          490 ms
test prepare_select_statment      ... ok          155 ms
test prepare_decimal              ... ok          203 ms
test manual_tutorial              ... ok          112 ms
test create_table_restrict        ... ok          198 ms

======================
 All 13 tests passed. 
======================
```