### PR TITLE
Fixed regression test expectations.

### DIFF
--- a/expected/create_table_restrict.out
+++ b/expected/create_table_restrict.out
@@ -15,7 +15,7 @@ CREATE EXTENSION tsurugi_fdw;
                    List of installed extensions
     Name     | Version | Schema |           Description            
 -------------+---------+--------+----------------------------------
- tsurugi_fdw | 1.0.0   | public | foreign-data wrapper for tsurugi
+ tsurugi_fdw | 1.1.0   | public | foreign-data wrapper for tsurugi
 (1 row)
 
 CREATE SERVER IF NOT EXISTS tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;

--- a/expected/test_preparation.out
+++ b/expected/test_preparation.out
@@ -4,6 +4,6 @@ CREATE SERVER IF NOT EXISTS tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
                    List of installed extensions
     Name     | Version | Schema |           Description            
 -------------+---------+--------+----------------------------------
- tsurugi_fdw | 1.0.0   | public | foreign-data wrapper for tsurugi
+ tsurugi_fdw | 1.1.0   | public | foreign-data wrapper for tsurugi
 (1 row)
 


### PR DESCRIPTION
Regression testing has improved.

## Regression Testing

### PostgreSQL 12

```shell-session
$ pg_ctl --version
pg_ctl (PostgreSQL) 12.4
```

```shell-session
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           12 ms
test create_table_happy           ... ok          222 ms
test create_index_happy           ... ok          192 ms
test insert_select_happy          ... ok          619 ms
test update_delete_happy          ... ok          410 ms
test select_statement_happy       ... ok          241 ms
test user_management_happy        ... ok          103 ms
test udf_transaction_happy        ... ok          660 ms
test prepare_statement_happy      ... ok          986 ms
test prepare_select_statement_happy ... ok          245 ms
test prepare_decimal_happy        ... ok          404 ms
test manual_tutorial              ... ok          167 ms
test import_foreign_schema_happy  ... ok         1817 ms
test udf_tg_show_tables_happy     ... ok          941 ms
test udf_tg_verify_tables_happy   ... ok         2756 ms
test create_table_unhappy         ... ok           34 ms
test insert_select_unhappy        ... ok          134 ms
test prepare_decimal_unhappy      ... ok           69 ms
test udf_transaction_unhappy      ... ok          303 ms
test update_delete_unhappy        ... ok          298 ms
test user_management_unhappy      ... ok           45 ms
test prepare_select_statement_unhappy ... ok           65 ms
test create_table_restrict        ... ok          783 ms
test import_foreign_schema_unhappy ... ok            6 ms
test import_foreign_schema_extra  ... ok        43256 ms
test udf_tg_show_tables_unhappy   ... ok          328 ms
test udf_tg_show_tables_extra     ... ok        45474 ms
test udf_tg_verify_tables_unhappy ... ok            8 ms
test udf_tg_verify_tables_extra   ... ok        51027 ms

======================
 All 29 tests passed.
======================
```

### PostgreSQL 13

```shell-session
$ pg_ctl --version
pg_ctl (PostgreSQL) 13.19
```

```shell-session
============== dropping database "contrib_regression" ==============
DROP DATABASE
============== creating database "contrib_regression" ==============
CREATE DATABASE
ALTER DATABASE
============== running regression test queries        ==============
test test_preparation             ... ok           11 ms
test create_table_happy           ... ok          196 ms
test create_index_happy           ... ok          189 ms
test insert_select_happy          ... ok          596 ms
test update_delete_happy          ... ok          380 ms
test select_statement_happy       ... ok          258 ms
test user_management_happy        ... ok           99 ms
test udf_transaction_happy        ... ok          712 ms
test prepare_statement_happy      ... ok          962 ms
test prepare_select_statement_happy ... ok          250 ms
test prepare_decimal_happy        ... ok          403 ms
test manual_tutorial              ... ok          163 ms
test import_foreign_schema_happy  ... ok         1849 ms
test udf_tg_show_tables_happy     ... ok         1083 ms
test udf_tg_verify_tables_happy   ... ok         3567 ms
test create_table_unhappy         ... ok           98 ms
test insert_select_unhappy        ... ok          352 ms
test prepare_decimal_unhappy      ... ok          177 ms
test udf_transaction_unhappy      ... ok          631 ms
test update_delete_unhappy        ... ok          770 ms
test user_management_unhappy      ... ok          125 ms
test prepare_select_statement_unhappy ... ok          189 ms
test create_table_restrict        ... ok         1706 ms
test import_foreign_schema_unhappy ... ok            6 ms
test import_foreign_schema_extra  ... ok        56094 ms
test udf_tg_show_tables_unhappy   ... ok           77 ms
test udf_tg_show_tables_extra     ... ok        53169 ms
test udf_tg_verify_tables_unhappy ... ok           11 ms
test udf_tg_verify_tables_extra   ... ok        54553 ms

======================
 All 29 tests passed.
======================
```