### PR TITLE
Added functionality to set the Tsurugi database name. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,9 @@ SHLIB_LINK = -logawayama-stub -lboost_filesystem
 
 EXTENSION = tsurugi_fdw
 DATA = tsurugi_fdw--1.3.0.sql \
-		tsurugi_fdw--1.0.0--1.1.0.sql
+		tsurugi_fdw--1.0.0--1.1.0.sql \
+		tsurugi_fdw--1.1.0--1.2.0.sql \
+		tsurugi_fdw--1.2.0--1.3.0.sql
 
 # REGRESS_BASIC: Run basic tests.
 # REGRESS_EXTRA: Run extra tests.

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ endif
 # Test settings according to regression test type
 REGRESS := test_preparation
 ifdef REGRESS_BASIC
-	REGRESS += dml_happy data_types_happy case_sensitive_happy \
+	REGRESS += ddl_happy \
+	           dml_happy data_types_happy case_sensitive_happy \
 	           prep_dml_happy prep_data_types_happy prep_case_sensitive_happy \
 	           manual_tutorial \
 	           udf_transaction_happy udf_tg_show_tables_happy udf_tg_verify_tables_happy \

--- a/expected/ddl_happy.out
+++ b/expected/ddl_happy.out
@@ -1,0 +1,437 @@
+/* Test case: happy path - Data Definition Language */
+-- SERVER OPTIONS
+--- Test setup: DDL of the PostgreSQL
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+--- Test case: CREATE SERVER: defaults
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+\des+ tsurugidb
+                                           List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description 
+-----------+----------+----------------------+-------------------+------+---------+-------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         |             | 
+(1 row)
+
+DROP SERVER tsurugidb;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw OPTIONS (endpoint 'ipc');
+\des+ tsurugidb
+                                              List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |   FDW options    | Description 
+-----------+----------+----------------------+-------------------+------+---------+------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (endpoint 'ipc') | 
+(1 row)
+
+DROP SERVER tsurugidb;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw OPTIONS (dbname 'test_db');
+\des+ tsurugidb
+                                               List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |    FDW options     | Description 
+-----------+----------+----------------------+-------------------+------+---------+--------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (dbname 'test_db') | 
+(1 row)
+
+DROP SERVER tsurugidb;
+--- Test case: CREATE SERVER ... /ALTER SERVER ...
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+\des+ tsurugidb
+                                           List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description 
+-----------+----------+----------------------+-------------------+------+---------+-------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         |             | 
+(1 row)
+
+ALTER SERVER tsurugidb OPTIONS (endpoint 'ipc', dbname 'test_db');
+\des+ tsurugidb
+                                                       List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |            FDW options             | Description 
+-----------+----------+----------------------+-------------------+------+---------+------------------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (endpoint 'ipc', dbname 'test_db') | 
+(1 row)
+
+ALTER SERVER tsurugidb OPTIONS (DROP endpoint, DROP dbname);
+\des+ tsurugidb
+                                           List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description 
+-----------+----------+----------------------+-------------------+------+---------+-------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         |             | 
+(1 row)
+
+ALTER SERVER tsurugidb
+  OPTIONS (endpoint 'stream', address '127.0.0.1', port '12345');
+\des+ tsurugidb
+                                                                 List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |                      FDW options                       | Description 
+-----------+----------+----------------------+-------------------+------+---------+--------------------------------------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (endpoint 'stream', address '127.0.0.1', port '12345') | 
+(1 row)
+
+ALTER SERVER tsurugidb OPTIONS (DROP endpoint, DROP address, DROP port);
+\des+ tsurugidb
+                                           List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description 
+-----------+----------+----------------------+-------------------+------+---------+-------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         |             | 
+(1 row)
+
+DROP SERVER tsurugidb;
+--- Test case: CREATE SERVER ... OPTIONS .../ALTER SERVER ...: IPC
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'ipc', dbname 'test_db');
+\des+ tsurugidb
+                                                       List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |            FDW options             | Description 
+-----------+----------+----------------------+-------------------+------+---------+------------------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (endpoint 'ipc', dbname 'test_db') | 
+(1 row)
+
+ALTER SERVER tsurugidb
+  OPTIONS (SET endpoint 'stream', address '127.0.0.1', port '12345', DROP dbname);
+\des+ tsurugidb
+                                                                 List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |                      FDW options                       | Description 
+-----------+----------+----------------------+-------------------+------+---------+--------------------------------------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (endpoint 'stream', address '127.0.0.1', port '12345') | 
+(1 row)
+
+ALTER SERVER tsurugidb
+  OPTIONS (SET endpoint 'ipc', dbname 'test_db', DROP address, DROP port);
+\des+ tsurugidb
+                                                       List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |            FDW options             | Description 
+-----------+----------+----------------------+-------------------+------+---------+------------------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (endpoint 'ipc', dbname 'test_db') | 
+(1 row)
+
+ALTER SERVER tsurugidb
+  OPTIONS (SET endpoint 'stream', address 'localhost', port '1');
+\des+ tsurugidb
+                                                                        List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |                             FDW options                              | Description 
+-----------+----------+----------------------+-------------------+------+---------+----------------------------------------------------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (endpoint 'stream', dbname 'test_db', address 'localhost', port '1') | 
+(1 row)
+
+ALTER SERVER tsurugidb OPTIONS (SET endpoint 'ipc', SET dbname 'test_db_2');
+\des+ tsurugidb
+                                                                       List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |                             FDW options                             | Description 
+-----------+----------+----------------------+-------------------+------+---------+---------------------------------------------------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (endpoint 'ipc', dbname 'test_db_2', address 'localhost', port '1') | 
+(1 row)
+
+DROP SERVER tsurugidb;
+--- Test case: CREATE SERVER ... OPTIONS .../ALTER SERVER ...: TCP
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '127.0.0.1', port '12345');
+\des+ tsurugidb
+                                                                 List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |                      FDW options                       | Description 
+-----------+----------+----------------------+-------------------+------+---------+--------------------------------------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (endpoint 'stream', address '127.0.0.1', port '12345') | 
+(1 row)
+
+DROP SERVER tsurugidb;
+--- Test case: case sensitivity
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (ENDPOINT 'ipc', DBNAME 'TEST_DB', ADDRESS '127.0.0.1', PORT '12345');
+\des+ tsurugidb
+                                                                        List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |                              FDW options                              | Description 
+-----------+----------+----------------------+-------------------+------+---------+-----------------------------------------------------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (endpoint 'ipc', dbname 'TEST_DB', address '127.0.0.1', port '12345') | 
+(1 row)
+
+DROP SERVER tsurugidb;
+--- Test teardown: DDL of the PostgreSQL
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+--- Basic operations
+---- Test setup: DDL of the Tsurugi
+SELECT tg_execute_ddl('
+  CREATE TABLE fdw_ddl_table (c INTEGER)
+', 'tsurugidb');
+ tg_execute_ddl 
+----------------
+ CREATE TABLE
+(1 row)
+
+---- Test case: INSERT is the first operation
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+INSERT INTO fdw_ddl_table VALUES (1), (2);
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+ 1
+ 2
+(2 rows)
+
+UPDATE fdw_ddl_table SET c = c + 10;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c  
+----
+ 11
+ 12
+(2 rows)
+
+DELETE FROM fdw_ddl_table WHERE c = 11;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c  
+----
+ 12
+(1 row)
+
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+---- Test case: SELECT is the first operation
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c  
+----
+ 12
+(1 row)
+
+UPDATE fdw_ddl_table SET c = c - 10;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+ 2
+(1 row)
+
+DELETE FROM fdw_ddl_table WHERE c = 2;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+(0 rows)
+
+INSERT INTO fdw_ddl_table VALUES (3);
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+ 3
+(1 row)
+
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+---- Test case: UPDATE is the first operation
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+UPDATE fdw_ddl_table SET c = c + 20;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c  
+----
+ 23
+(1 row)
+
+DELETE FROM fdw_ddl_table WHERE c = 23;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+(0 rows)
+
+INSERT INTO fdw_ddl_table VALUES (4);
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+ 4
+(1 row)
+
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+---- Test case: DELETE is the first operation
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+DELETE FROM fdw_ddl_table WHERE c = 4;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+(0 rows)
+
+INSERT INTO fdw_ddl_table VALUES (5);
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+ 5
+(1 row)
+
+UPDATE fdw_ddl_table SET c = 111;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+  c  
+-----
+ 111
+(1 row)
+
+DELETE FROM fdw_ddl_table;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+(0 rows)
+
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+---- Test case: INSERT (preparation) is the first operation
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+PREPARE fdw_prepare_ins(integer, integer) AS
+  INSERT INTO fdw_ddl_table VALUES ($1), ($2);
+PREPARE fdw_prepare_sel AS SELECT * FROM fdw_ddl_table ORDER BY c;
+PREPARE fdw_prepare_upd(integer) AS UPDATE fdw_ddl_table SET c = c + $1;
+PREPARE fdw_prepare_del(integer) AS DELETE FROM fdw_ddl_table WHERE c = $1;
+EXECUTE fdw_prepare_ins(1, 2);
+EXECUTE fdw_prepare_sel;
+ c 
+---
+ 1
+ 2
+(2 rows)
+
+EXECUTE fdw_prepare_upd(10);
+EXECUTE fdw_prepare_sel;
+ c  
+----
+ 11
+ 12
+(2 rows)
+
+EXECUTE fdw_prepare_del(11);
+EXECUTE fdw_prepare_sel;
+ c  
+----
+ 12
+(1 row)
+
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+---- Test case: SELECT (preparation) is the first operation
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+PREPARE fdw_prepare_ins(integer) AS INSERT INTO fdw_ddl_table VALUES ($1);
+PREPARE fdw_prepare_sel AS SELECT * FROM fdw_ddl_table ORDER BY c;
+PREPARE fdw_prepare_upd(integer) AS UPDATE fdw_ddl_table SET c = c + $1;
+PREPARE fdw_prepare_del(integer) AS DELETE FROM fdw_ddl_table WHERE c = $1;
+EXECUTE fdw_prepare_sel;
+ c  
+----
+ 12
+(1 row)
+
+EXECUTE fdw_prepare_upd(-10);
+EXECUTE fdw_prepare_sel;
+ c 
+---
+ 2
+(1 row)
+
+EXECUTE fdw_prepare_del(2);
+EXECUTE fdw_prepare_sel;
+ c 
+---
+(0 rows)
+
+EXECUTE fdw_prepare_ins(3);
+EXECUTE fdw_prepare_sel;
+ c 
+---
+ 3
+(1 row)
+
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+---- Test case: UPDATE (preparation) is the first operation
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+PREPARE fdw_prepare_ins(integer) AS INSERT INTO fdw_ddl_table VALUES ($1);
+PREPARE fdw_prepare_sel AS SELECT * FROM fdw_ddl_table ORDER BY c;
+PREPARE fdw_prepare_upd(integer) AS UPDATE fdw_ddl_table SET c = c + $1;
+PREPARE fdw_prepare_del(integer) AS DELETE FROM fdw_ddl_table WHERE c = $1;
+EXECUTE fdw_prepare_upd(20);
+EXECUTE fdw_prepare_sel;
+ c  
+----
+ 23
+(1 row)
+
+EXECUTE fdw_prepare_del(23);
+EXECUTE fdw_prepare_sel;
+ c 
+---
+(0 rows)
+
+EXECUTE fdw_prepare_ins(4);
+EXECUTE fdw_prepare_sel;
+ c 
+---
+ 4
+(1 row)
+
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+---- Test case: DELETE (preparation) is the first operation
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+PREPARE fdw_prepare_ins AS INSERT INTO fdw_ddl_table VALUES (5);
+PREPARE fdw_prepare_sel AS SELECT * FROM fdw_ddl_table ORDER BY c;
+PREPARE fdw_prepare_upd AS UPDATE fdw_ddl_table SET c = 111;
+PREPARE fdw_prepare_del(integer) AS DELETE FROM fdw_ddl_table WHERE c = $1;
+PREPARE fdw_prepare_del_all AS DELETE FROM fdw_ddl_table;
+EXECUTE fdw_prepare_del(4);
+EXECUTE fdw_prepare_sel;
+ c 
+---
+(0 rows)
+
+EXECUTE fdw_prepare_ins;
+EXECUTE fdw_prepare_sel;
+ c 
+---
+ 5
+(1 row)
+
+EXECUTE fdw_prepare_upd;
+EXECUTE fdw_prepare_sel;
+  c  
+-----
+ 111
+(1 row)
+
+EXECUTE fdw_prepare_del_all;
+EXECUTE fdw_prepare_sel;
+ c 
+---
+(0 rows)
+
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+---- Test teardown: DDL of the Tsurugi
+SELECT tg_execute_ddl('DROP TABLE fdw_ddl_table', 'tsurugidb');
+ tg_execute_ddl 
+----------------
+ DROP TABLE
+(1 row)
+

--- a/expected/ddl_happy.out
+++ b/expected/ddl_happy.out
@@ -146,8 +146,7 @@ DROP SERVER tsurugidb;
 --- Test teardown: DDL of the PostgreSQL
 \c contrib_regression
 DROP DATABASE contrib_regression_ddl;
---- Basic operations
----- Test setup: DDL of the Tsurugi
+--- Test setup: DDL of the Tsurugi
 SELECT tg_execute_ddl('
   CREATE TABLE fdw_ddl_table (c INTEGER)
 ', 'tsurugidb');
@@ -156,6 +155,7 @@ SELECT tg_execute_ddl('
  CREATE TABLE
 (1 row)
 
+--- Basic operations
 ---- Test case: INSERT is the first operation
 CREATE DATABASE contrib_regression_ddl;
 \c contrib_regression_ddl
@@ -428,7 +428,227 @@ EXECUTE fdw_prepare_sel;
 
 \c contrib_regression
 DROP DATABASE contrib_regression_ddl;
----- Test teardown: DDL of the Tsurugi
+--- Operations during a transaction
+---- Test setup: DDL of the PostgreSQL
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+---- Test case: Create server - COMMIT
+BEGIN;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+\des+
+                                           List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description 
+-----------+----------+----------------------+-------------------+------+---------+-------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         |             | 
+(1 row)
+
+COMMIT;
+\des+
+                                           List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description 
+-----------+----------+----------------------+-------------------+------+---------+-------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         |             | 
+(1 row)
+
+---- Test case: Re-create server - COMMIT
+BEGIN;
+DROP SERVER tsurugidb;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw OPTIONS (endpoint 'ipc');
+\des+
+                                              List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |   FDW options    | Description 
+-----------+----------+----------------------+-------------------+------+---------+------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (endpoint 'ipc') | 
+(1 row)
+
+COMMIT;
+\des+
+                                              List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |   FDW options    | Description 
+-----------+----------+----------------------+-------------------+------+---------+------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (endpoint 'ipc') | 
+(1 row)
+
+---- Test case: Re-create server - ROLLBACK
+BEGIN;
+DROP SERVER tsurugidb;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '127.0.0.1', port '12345');
+\des+
+                                                                 List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |                      FDW options                       | Description 
+-----------+----------+----------------------+-------------------+------+---------+--------------------------------------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (endpoint 'stream', address '127.0.0.1', port '12345') | 
+(1 row)
+
+ROLLBACK;
+\des+
+                                              List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |   FDW options    | Description 
+-----------+----------+----------------------+-------------------+------+---------+------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (endpoint 'ipc') | 
+(1 row)
+
+---- Test re-setup: DDL of the PostgreSQL
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+---- Test case: Alter server (incorrect server) - Connected in a transaction
+BEGIN;
+INSERT INTO fdw_ddl_table VALUES (1), (2);
+ALTER SERVER tsurugidb OPTIONS (dbname 'incorrect_dbname');
+\des+
+                                                   List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |         FDW options         | Description 
+-----------+----------+----------------------+-------------------+------+---------+-----------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (dbname 'incorrect_dbname') | 
+(1 row)
+
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+ 1
+ 2
+(2 rows)
+
+ROLLBACK;
+\des+
+                                           List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description 
+-----------+----------+----------------------+-------------------+------+---------+-------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         |             | 
+(1 row)
+
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+(0 rows)
+
+---- Test re-setup: DDL of the PostgreSQL
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+---- Test case: Alter server (correct server) - Connected in a transaction
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+(0 rows)
+
+ALTER SERVER tsurugidb OPTIONS (dbname 'incorrect_dbname');
+\des+
+                                                   List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |         FDW options         | Description 
+-----------+----------+----------------------+-------------------+------+---------+-----------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (dbname 'incorrect_dbname') | 
+(1 row)
+
+BEGIN;
+ALTER SERVER tsurugidb OPTIONS (SET dbname 'tsurugi');
+\des+
+                                               List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |    FDW options     | Description 
+-----------+----------+----------------------+-------------------+------+---------+--------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (dbname 'tsurugi') | 
+(1 row)
+
+INSERT INTO fdw_ddl_table VALUES (1), (2);
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+ 1
+ 2
+(2 rows)
+
+ROLLBACK;
+\des+
+                                                   List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |         FDW options         | Description 
+-----------+----------+----------------------+-------------------+------+---------+-----------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (dbname 'incorrect_dbname') | 
+(1 row)
+
+---- Test re-setup: DDL of the PostgreSQL
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+---- Test case: ALTER SERVER during operations
+BEGIN;
+INSERT INTO fdw_ddl_table VALUES (3), (4);
+ALTER SERVER tsurugidb OPTIONS (dbname 'incorrect-1');
+\des+
+                                                 List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |      FDW options       | Description 
+-----------+----------+----------------------+-------------------+------+---------+------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (dbname 'incorrect-1') | 
+(1 row)
+
+UPDATE fdw_ddl_table SET c=c+10;
+ALTER SERVER tsurugidb OPTIONS (SET dbname 'incorrect-2');
+\des+
+                                                 List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |      FDW options       | Description 
+-----------+----------+----------------------+-------------------+------+---------+------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (dbname 'incorrect-2') | 
+(1 row)
+
+DELETE FROM fdw_ddl_table WHERE c=14;
+ALTER SERVER tsurugidb OPTIONS (SET dbname 'incorrect-3');
+\des+
+                                                 List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |      FDW options       | Description 
+-----------+----------+----------------------+-------------------+------+---------+------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (dbname 'incorrect-3') | 
+(1 row)
+
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c  
+----
+ 13
+(1 row)
+
+ALTER SERVER tsurugidb OPTIONS (SET dbname 'incorrect-4');
+\des+
+                                                 List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |      FDW options       | Description 
+-----------+----------+----------------------+-------------------+------+---------+------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (dbname 'incorrect-4') | 
+(1 row)
+
+END;
+BEGIN;
+ALTER SERVER tsurugidb OPTIONS (DROP dbname);
+\des+
+                                           List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description 
+-----------+----------+----------------------+-------------------+------+---------+-------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         |             | 
+(1 row)
+
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c  
+----
+ 13
+(1 row)
+
+DELETE FROM fdw_ddl_table;
+END;
+---- Test teardown: DDL of the PostgreSQL
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+--- Test teardown: DDL of the Tsurugi
 SELECT tg_execute_ddl('DROP TABLE fdw_ddl_table', 'tsurugidb');
  tg_execute_ddl 
 ----------------

--- a/expected/ddl_unhappy.out
+++ b/expected/ddl_unhappy.out
@@ -1,8 +1,9 @@
 /* Test case: unhappy path - Data Definition Language */
--- Test setup: DDL of the PostgreSQL
-CREATE DATABASE contrib_regression2;
-\c contrib_regression2
--- Test
+-- EXTENSION
+--- Test setup: DDL of the PostgreSQL
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+--- Test case: table exists before
 CREATE TABLE tsurugifdw_regressiontest(id INT);
 CREATE EXTENSION tsurugi_fdw;
 ERROR:  tsurugi_fdw extension cannot be installed in the non-empty database. Please make sure there are no tables by using the \d command.
@@ -13,6 +14,7 @@ ERROR:  tsurugi_fdw extension cannot be installed in the non-empty database. Ple
 (0 rows)
 
 DROP TABLE tsurugifdw_regressiontest;
+--- Test case: table does not exist
 CREATE EXTENSION tsurugi_fdw;
 \dx tsurugi_fdw
                    List of installed extensions
@@ -21,6 +23,8 @@ CREATE EXTENSION tsurugi_fdw;
  tsurugi_fdw | 1.3.0   | public | foreign-data wrapper for tsurugi
 (1 row)
 
+--- Test case: DDL restriction - tsurugi_fdw is enabled
+---- Test setup: DDL of the PostgreSQL
 CREATE SERVER IF NOT EXISTS tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
 CREATE FOREIGN TABLE tsurugifdw_regressiontest(id INT) SERVER tsurugidb;
 SELECT EXISTS (
@@ -32,7 +36,7 @@ SELECT EXISTS (
  t
 (1 row)
 
--- error (CREATE TABLE)
+---- CREATE TABLE
 CREATE TABLE t0_create_table(c1 INTEGER NOT NULL);
 ERROR:  This database is for Tsurugi, so CREATE TABLE is not supported
 SELECT * FROM t0_create_table;
@@ -105,7 +109,7 @@ SELECT * FROM temp_table1;
 ERROR:  relation "temp_table1" does not exist
 LINE 1: SELECT * FROM temp_table1;
                       ^
--- error (CREATE TABLE AS)
+---- CREATE TABLE AS
 CREATE TABLE t1_create_table_as AS SELECT * FROM tsurugifdw_regressiontest;
 ERROR:  This database is for Tsurugi, so CREATE TABLE AS is not supported
 SELECT * FROM t1_create_table_as;
@@ -118,11 +122,13 @@ SELECT * FROM t2_create_table_as;
 ERROR:  relation "t2_create_table_as" does not exist
 LINE 1: SELECT * FROM t2_create_table_as;
                       ^
+--- Test case: DDL restriction - tsurugi_fdw is disabled
+---- Test setup: DDL of the PostgreSQL
 DROP EXTENSION tsurugi_fdw CASCADE;
 NOTICE:  drop cascades to 2 other objects
 DETAIL:  drop cascades to server tsurugidb
 drop cascades to foreign table tsurugifdw_regressiontest
--- Success (CREATE TABLE)
+---- CREATE TABLE
 CREATE TABLE t0_create_table(c1 INTEGER NOT NULL);
 SELECT * FROM t0_create_table;
  c1 
@@ -195,7 +201,7 @@ SELECT * FROM temp_table1;
 ----
 (0 rows)
 
--- Success (CREATE TABLE AS)
+---- CREATE TABLE AS
 CREATE TABLE t1_create_table_as AS SELECT * FROM t0_create_table;
 SELECT * FROM t1_create_table_as;
  c1 
@@ -208,6 +214,220 @@ SELECT * FROM t2_create_table_as;
 ----
 (0 rows)
 
--- Test teardown: DDL of the PostgreSQL
+--- Test teardown: DDL of the PostgreSQL
 \c contrib_regression
-DROP DATABASE contrib_regression2;
+DROP DATABASE contrib_regression_ddl;
+-- SERVER OPTIONS
+--- Test setup: DDL of the Tsurugi
+SELECT tg_execute_ddl('
+  CREATE TABLE fdw_ddl_table (c INTEGER)
+', 'tsurugidb');
+ tg_execute_ddl 
+----------------
+ CREATE TABLE
+(1 row)
+
+--- Test setup: DDL of the PostgreSQL
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+--- Test case: option name validation
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (invalid_option 'value');
+ERROR:  invalid option "invalid_option"
+--- Test case: required options validation
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream');
+ERROR:  missing required option "address"
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '127.0.0.1');
+ERROR:  missing required option "port"
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', port '12345');
+ERROR:  missing required option "address"
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+ALTER SERVER tsurugidb OPTIONS (endpoint 'stream');
+ERROR:  missing required option "address"
+ALTER SERVER tsurugidb OPTIONS (endpoint 'stream', address '127.0.0.1');
+ERROR:  missing required option "port"
+ALTER SERVER tsurugidb OPTIONS (endpoint 'stream', port '12345');
+ERROR:  missing required option "address"
+DROP SERVER tsurugidb;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '127.0.0.1', port '12345');
+ALTER SERVER tsurugidb OPTIONS (DROP address);
+ERROR:  missing required option "address"
+ALTER SERVER tsurugidb OPTIONS (DROP port);
+ERROR:  missing required option "port"
+ALTER SERVER tsurugidb OPTIONS (DROP address, DROP port);
+ERROR:  missing required option "address"
+DROP SERVER tsurugidb;
+--- Test case: endpoint option validation
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'invalid_value');
+ERROR:  invalid value ("invalid_value") for option "endpoint"
+DETAIL:  expected 'ipc' or 'stream'
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'IPC');
+ERROR:  invalid value ("IPC") for option "endpoint"
+DETAIL:  expected 'ipc' or 'stream'
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'STREAM');
+ERROR:  invalid value ("STREAM") for option "endpoint"
+DETAIL:  expected 'ipc' or 'stream'
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint ' ipc');
+ERROR:  invalid value (" ipc") for option "endpoint"
+DETAIL:  expected 'ipc' or 'stream'
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'ipc ');
+ERROR:  invalid value ("ipc ") for option "endpoint"
+DETAIL:  expected 'ipc' or 'stream'
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint '');
+ERROR:  option "endpoint" requires a non-empty value
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint ' ');
+ERROR:  option "endpoint" requires a non-empty value
+--- Test case: dbname option validation
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'ipc', dbname '');
+ERROR:  option "dbname" requires a non-empty value
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'ipc', dbname ' ');
+ERROR:  option "dbname" requires a non-empty value
+--- Test case: address option validation
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '', port '12345');
+ERROR:  option "address" requires a non-empty value
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address ' ', port '12345');
+ERROR:  option "address" requires a non-empty value
+--- Test case: port option validation
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '127.0.0.1', port '');
+ERROR:  option "port" requires a non-empty value
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '127.0.0.1', port ' ');
+ERROR:  option "port" requires a non-empty value
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '127.0.0.1', port '0');
+ERROR:  "port" must be an integer value greater than zero: 0
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '127.0.0.1', port 'abc');
+ERROR:  "port" must be an integer value greater than zero: abc
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '127.0.0.1', port '-1');
+ERROR:  "port" must be an integer value greater than zero: -1
+--- Test case: dbname option value is incorrect
+---- Test setup: DDL of the PostgreSQL
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+---- correct -> incorrect
+ALTER SERVER tsurugidb OPTIONS (ADD dbname 'incorrect_dbname');
+INSERT INTO fdw_ddl_table VALUES (1);
+ERROR:  Failed to execute remote SQL.
+HINT:  Failed to make shared memory for Tsurugi. error: SERVER_FAILURE(10)
+No detail message.
+CONTEXT:  SQL query: 
+UPDATE fdw_ddl_table SET c = c + 10;
+ERROR:  Failed to execute remote SQL.
+HINT:  Failed to make shared memory for Tsurugi. error: SERVER_FAILURE(10)
+No detail message.
+CONTEXT:  SQL query: 
+DELETE FROM fdw_ddl_table;
+ERROR:  Failed to execute remote SQL.
+HINT:  Failed to make shared memory for Tsurugi. error: SERVER_FAILURE(10)
+No detail message.
+CONTEXT:  SQL query: 
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ERROR:  Failed to execute remote SQL.
+HINT:  Failed to make shared memory for Tsurugi. error: SERVER_FAILURE(10)
+No detail message.
+CONTEXT:  SQL query: 
+---- incorrect -> correct
+ALTER SERVER tsurugidb OPTIONS (DROP dbname);
+INSERT INTO fdw_ddl_table VALUES (2);
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+ 2
+(1 row)
+
+UPDATE fdw_ddl_table SET c = c + 20;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c  
+----
+ 22
+(1 row)
+
+DELETE FROM fdw_ddl_table;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+(0 rows)
+
+---- Test setup: PREPARE statements
+PREPARE fdw_prepare_ins(integer) AS INSERT INTO fdw_ddl_table VALUES ($1);
+PREPARE fdw_prepare_upd(integer) AS UPDATE fdw_ddl_table SET c = c + $1;
+PREPARE fdw_prepare_del AS DELETE FROM fdw_ddl_table;
+PREPARE fdw_prepare_sel AS SELECT * FROM fdw_ddl_table ORDER BY c;
+---- correct -> incorrect (preparation)
+ALTER SERVER tsurugidb OPTIONS (ADD dbname 'incorrect_dbname');
+EXECUTE fdw_prepare_ins(1);
+ERROR:  Failed to execute remote SQL.
+HINT:  Failed to make shared memory for Tsurugi. error: SERVER_FAILURE(10)
+No detail message.
+CONTEXT:  SQL query: 
+EXECUTE fdw_prepare_upd(10);
+ERROR:  Failed to execute remote SQL.
+HINT:  Failed to make shared memory for Tsurugi. error: SERVER_FAILURE(10)
+No detail message.
+CONTEXT:  SQL query: 
+EXECUTE fdw_prepare_del;
+ERROR:  Failed to execute remote SQL.
+HINT:  Failed to make shared memory for Tsurugi. error: SERVER_FAILURE(10)
+No detail message.
+CONTEXT:  SQL query: 
+EXECUTE fdw_prepare_sel;
+ERROR:  Failed to execute remote SQL.
+HINT:  Failed to make shared memory for Tsurugi. error: SERVER_FAILURE(10)
+No detail message.
+CONTEXT:  SQL query: 
+---- incorrect -> correct (preparation)
+ALTER SERVER tsurugidb OPTIONS (SET dbname 'tsurugi');
+EXECUTE fdw_prepare_ins(2);
+EXECUTE fdw_prepare_sel;
+ c 
+---
+ 2
+(1 row)
+
+EXECUTE fdw_prepare_upd(20);
+EXECUTE fdw_prepare_sel;
+ c  
+----
+ 22
+(1 row)
+
+EXECUTE fdw_prepare_del;
+EXECUTE fdw_prepare_sel;
+ c 
+---
+(0 rows)
+
+---- Test teardown: PREPARE statements
+DEALLOCATE fdw_prepare_ins;
+DEALLOCATE fdw_prepare_sel;
+DEALLOCATE fdw_prepare_upd;
+DEALLOCATE fdw_prepare_del;
+--- Test teardown: DDL of the PostgreSQL
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+--- Test teardown: DDL of the Tsurugi
+SELECT tg_execute_ddl('DROP TABLE fdw_ddl_table', 'tsurugidb');
+ tg_execute_ddl 
+----------------
+ DROP TABLE
+(1 row)
+

--- a/expected/ddl_unhappy.out
+++ b/expected/ddl_unhappy.out
@@ -421,6 +421,202 @@ DEALLOCATE fdw_prepare_ins;
 DEALLOCATE fdw_prepare_sel;
 DEALLOCATE fdw_prepare_upd;
 DEALLOCATE fdw_prepare_del;
+---- Test setup: DDL of the PostgreSQL
+DROP FOREIGN TABLE fdw_ddl_table;
+DROP SERVER tsurugidb;
+--- Operations during a transaction
+---- Test re-setup: DDL of the PostgreSQL
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+---- Test case: Alter server (incorrect server) - Connected outside a transaction
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+(0 rows)
+
+BEGIN;
+ALTER SERVER tsurugidb OPTIONS (dbname 'incorrect');
+\des+
+                                                List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |     FDW options      | Description 
+-----------+----------+----------------------+-------------------+------+---------+----------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (dbname 'incorrect') | 
+(1 row)
+
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ERROR:  Failed to execute remote SQL.
+HINT:  Failed to make shared memory for Tsurugi. error: SERVER_FAILURE(10)
+No detail message.
+CONTEXT:  SQL query: 
+END;
+\des+
+                                           List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description 
+-----------+----------+----------------------+-------------------+------+---------+-------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         |             | 
+(1 row)
+
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+(0 rows)
+
+---- Test case: Alter server (correct server) - Connected in a transaction
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+(0 rows)
+
+ALTER SERVER tsurugidb OPTIONS (dbname 'incorrect');
+\des+
+                                                List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |     FDW options      | Description 
+-----------+----------+----------------------+-------------------+------+---------+----------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (dbname 'incorrect') | 
+(1 row)
+
+BEGIN;
+INSERT INTO fdw_ddl_table VALUES (1), (2);
+ERROR:  Failed to execute remote SQL.
+HINT:  Failed to make shared memory for Tsurugi. error: SERVER_FAILURE(10)
+No detail message.
+CONTEXT:  SQL query: 
+END;
+BEGIN;
+ALTER SERVER tsurugidb OPTIONS (SET dbname 'tsurugi');
+INSERT INTO fdw_ddl_table VALUES (1), (2);
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+ 1
+ 2
+(2 rows)
+
+END;
+---- Test re-setup: DDL of the PostgreSQL
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+---- Test case: ALTER SERVER during operations
+BEGIN;
+INSERT INTO fdw_ddl_table VALUES (3), (4);
+ALTER SERVER tsurugidb OPTIONS (dbname 'incorrect-1');
+\des+
+                                                 List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |      FDW options       | Description 
+-----------+----------+----------------------+-------------------+------+---------+------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (dbname 'incorrect-1') | 
+(1 row)
+
+UPDATE fdw_ddl_table SET c=c+10;
+ALTER SERVER tsurugidb OPTIONS (SET dbname 'incorrect-2');
+\des+
+                                                 List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |      FDW options       | Description 
+-----------+----------+----------------------+-------------------+------+---------+------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (dbname 'incorrect-2') | 
+(1 row)
+
+DELETE FROM fdw_ddl_table WHERE c=14;
+ALTER SERVER tsurugidb OPTIONS (SET dbname 'incorrect-3');
+\des+
+                                                 List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |      FDW options       | Description 
+-----------+----------+----------------------+-------------------+------+---------+------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (dbname 'incorrect-3') | 
+(1 row)
+
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c  
+----
+ 11
+ 12
+ 13
+(3 rows)
+
+ALTER SERVER tsurugidb OPTIONS (SET dbname 'incorrect-4');
+\des+
+                                                 List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |      FDW options       | Description 
+-----------+----------+----------------------+-------------------+------+---------+------------------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         | (dbname 'incorrect-4') | 
+(1 row)
+
+END;
+BEGIN;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ERROR:  Failed to execute remote SQL.
+HINT:  Failed to make shared memory for Tsurugi. error: SERVER_FAILURE(10)
+No detail message.
+CONTEXT:  SQL query: 
+END;
+ALTER SERVER tsurugidb OPTIONS (DROP dbname);
+\des+
+                                           List of foreign servers
+   Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description 
+-----------+----------+----------------------+-------------------+------+---------+-------------+-------------
+ tsurugidb | postgres | tsurugi_fdw          |                   |      |         |             | 
+(1 row)
+
+BEGIN;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c  
+----
+ 11
+ 12
+ 13
+(3 rows)
+
+DELETE FROM fdw_ddl_table;
+END;
+--- Test re-setup: DDL of the PostgreSQL
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+--- Test case: ALTER SERVER during operations
+INSERT INTO fdw_ddl_table VALUES (1), (2);
+ALTER SERVER tsurugidb OPTIONS (dbname 'incorrect');
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ERROR:  Failed to execute remote SQL.
+HINT:  Failed to make shared memory for Tsurugi. error: SERVER_FAILURE(10)
+No detail message.
+CONTEXT:  SQL query: 
+ALTER SERVER tsurugidb OPTIONS (SET dbname 'tsurugi');
+UPDATE fdw_ddl_table SET c=c+10;
+ALTER SERVER tsurugidb OPTIONS (DROP dbname);
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c  
+----
+ 11
+ 12
+(2 rows)
+
+ALTER SERVER tsurugidb OPTIONS (dbname 'incorrect');
+DELETE FROM fdw_ddl_table;
+ERROR:  Failed to execute remote SQL.
+HINT:  Failed to make shared memory for Tsurugi. error: SERVER_FAILURE(10)
+No detail message.
+CONTEXT:  SQL query: 
+ALTER SERVER tsurugidb OPTIONS (SET dbname 'tsurugi');
+DELETE FROM fdw_ddl_table;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+ c 
+---
+(0 rows)
+
 --- Test teardown: DDL of the PostgreSQL
 \c contrib_regression
 DROP DATABASE contrib_regression_ddl;

--- a/expected/test_cleanup.out
+++ b/expected/test_cleanup.out
@@ -4,6 +4,12 @@ SELECT tg_execute_ddl('DROP TABLE IF EXISTS fdw_case_table', 'tsurugidb');
  DROP TABLE
 (1 row)
 
+SELECT tg_execute_ddl('DROP TABLE IF EXISTS fdw_ddl_table', 'tsurugidb');
+ tg_execute_ddl 
+----------------
+ DROP TABLE
+(1 row)
+
 SELECT tg_execute_ddl('DROP TABLE IF EXISTS fdw_del_variation_table', 'tsurugidb');
  tg_execute_ddl 
 ----------------

--- a/expected/udf_tg_show_tables_happy.out
+++ b/expected/udf_tg_show_tables_happy.out
@@ -783,9 +783,12 @@ SELECT tg_show_tables('tg_schema', 'tsurugidb');
      "remote_schema": {               +
          "remote_schema": "tg_schema",+
          "server_name": "tsurugidb",  +
-         "mode": "summary",           +
+         "mode": "detail",            +
          "tables_on_remote_schema": { +
-             "count": 1               +
+             "count": 1,              +
+             "list": [                +
+                 "udf_test_table_1"   +
+             ]                        +
          }                            +
      }                                +
  }

--- a/include/common/tsurugi.h
+++ b/include/common/tsurugi.h
@@ -37,28 +37,30 @@ extern "C" {
 
 class Tsurugi {
 public:
-	static ERROR_CODE init();
+	static ERROR_CODE init(Oid server_oid);
     static ERROR_CODE start_transaction();
     static bool in_transaction_block() { return (transaction_ != nullptr); }
     static ERROR_CODE commit();
     static ERROR_CODE rollback();
 
-    static bool exsists_prepared_statement(std::string_view name);
+    static bool exists_prepared_statement(std::string_view name);
+#if 0  // Not used
     static ERROR_CODE prepare(std::string_view sql,
                               ogawayama::stub::placeholders_type& placeholders,
                               PreparedStatementPtr& prepared_statement);
     static ERROR_CODE prepare(std::string_view name, std::string_view statement,
                               ogawayama::stub::placeholders_type& placeholders);
+#endif  // Not used
     static ERROR_CODE prepare(std::string_view statement,
                               ogawayama::stub::placeholders_type& placeholders);
-	static ERROR_CODE deallocate(std::string_view prep_name);
+    static ERROR_CODE deallocate(std::string_view prep_name);
     static void deallocate();
     static ERROR_CODE execute_query(std::string_view query);
     static ERROR_CODE execute_query(ogawayama::stub::parameters_type& params);
-    static ERROR_CODE execute_statement(std::string_view statement, 
+    static ERROR_CODE execute_statement(std::string_view statement,
                                         std::size_t& num_rows);
-    static ERROR_CODE execute_statement(std::string_view prep_name, 
-                                        ogawayama::stub::parameters_type& params, 
+    static ERROR_CODE execute_statement(std::string_view prep_name,
+                                        ogawayama::stub::parameters_type& params,
                                         std::size_t& num_rows);
     static ERROR_CODE execute_statement(ogawayama::stub::parameters_type& params, 
                                         std::size_t& num_rows);
@@ -78,12 +80,12 @@ public:
     static void report_error(const char* message, ERROR_CODE error, std::string_view sql);
 
     static ERROR_CODE get_list_tables(TableListPtr& table_list);
-    static ERROR_CODE get_table_metadata(std::string_view table_name, 
-            TableMetadataPtr& table_metadata);
+    static ERROR_CODE get_table_metadata(std::string_view table_name,
+                                         TableMetadataPtr& table_metadata);
 
-	static std::optional<std::string_view> 
+    static std::optional<std::string_view> 
         convert_type_to_pg(jogasaki::proto::sql::common::AtomType tg_type);
-	static std::pair<bool, Datum> convert_type_to_pg(ResultSetPtr result_set, 
+    static std::pair<bool, Datum> convert_type_to_pg(ResultSetPtr result_set, 
                                                      const Oid pgtype);
     static ogawayama::stub::Metadata::ColumnType::Type 
         get_tg_column_type(const Oid pg_type);
@@ -93,12 +95,12 @@ public:
     static ogawayama::stub::value_type
             get_tg_value_type(const Oid pg_type, Datum value);
 */
-	Tsurugi() = delete;
+    Tsurugi() = delete;
 
 private:
-	static StubPtr stub_;
-	static ConnectionPtr connection_;
-	static TransactionPtr transaction_;
+    static StubPtr stub_;
+    static ConnectionPtr connection_;
+    static TransactionPtr transaction_;
     static std::unordered_map<std::string, PreparedStatementPtr> prepared_statements_;
     static PreparedStatementPtr prepared_statement_;
     static ResultSetPtr result_set_;

--- a/include/common/tsurugi.h
+++ b/include/common/tsurugi.h
@@ -37,6 +37,7 @@ extern "C" {
 
 class Tsurugi {
 public:
+	static bool is_initialized(Oid server_oid);
 	static ERROR_CODE init(Oid server_oid);
     static ERROR_CODE start_transaction();
     static bool in_transaction_block() { return (transaction_ != nullptr); }

--- a/include/common/tsurugi.h
+++ b/include/common/tsurugi.h
@@ -37,9 +37,7 @@ extern "C" {
 
 class Tsurugi {
 public:
-	static bool is_initialized(Oid server_oid);
-	static ERROR_CODE init(Oid server_oid);
-    static ERROR_CODE start_transaction();
+    static ERROR_CODE start_transaction(Oid server_oid);
     static bool in_transaction_block() { return (transaction_ != nullptr); }
     static ERROR_CODE commit();
     static ERROR_CODE rollback();
@@ -52,10 +50,10 @@ public:
     static ERROR_CODE prepare(std::string_view name, std::string_view statement,
                               ogawayama::stub::placeholders_type& placeholders);
 #endif  // Not used
-    static ERROR_CODE prepare(std::string_view statement,
-                              ogawayama::stub::placeholders_type& placeholders);
-    static ERROR_CODE deallocate(std::string_view prep_name);
-    static void deallocate();
+	static ERROR_CODE prepare(Oid server_oid, std::string_view statement,
+							  ogawayama::stub::placeholders_type& placeholders);
+	static ERROR_CODE deallocate(std::string_view prep_name);
+	static void deallocate();
     static ERROR_CODE execute_query(std::string_view query);
     static ERROR_CODE execute_query(ogawayama::stub::parameters_type& params);
     static ERROR_CODE execute_statement(std::string_view statement,
@@ -80,11 +78,11 @@ public:
     static void report_error(const char* message, ERROR_CODE error, const char* sql);
     static void report_error(const char* message, ERROR_CODE error, std::string_view sql);
 
-    static ERROR_CODE get_list_tables(TableListPtr& table_list);
-    static ERROR_CODE get_table_metadata(std::string_view table_name,
-                                         TableMetadataPtr& table_metadata);
+	static ERROR_CODE get_list_tables(Oid server_oid, TableListPtr& table_list);
+	static ERROR_CODE get_table_metadata(Oid server_oid, std::string_view table_name,
+										 TableMetadataPtr& table_metadata);
 
-    static std::optional<std::string_view> 
+	static std::optional<std::string_view> 
         convert_type_to_pg(jogasaki::proto::sql::common::AtomType tg_type);
     static std::pair<bool, Datum> convert_type_to_pg(ResultSetPtr result_set, 
                                                      const Oid pgtype);
@@ -97,6 +95,10 @@ public:
             get_tg_value_type(const Oid pg_type, Datum value);
 */
     Tsurugi() = delete;
+
+private:
+    static ERROR_CODE init(Oid server_oid);
+    static bool is_initialized(Oid server_oid);
 
 private:
     static StubPtr stub_;

--- a/sql/ddl_happy.sql
+++ b/sql/ddl_happy.sql
@@ -1,0 +1,258 @@
+/* Test case: happy path - Data Definition Language */
+
+-- SERVER OPTIONS
+--- Test setup: DDL of the PostgreSQL
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+
+--- Test case: CREATE SERVER: defaults
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+\des+ tsurugidb
+DROP SERVER tsurugidb;
+
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw OPTIONS (endpoint 'ipc');
+\des+ tsurugidb
+DROP SERVER tsurugidb;
+
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw OPTIONS (dbname 'test_db');
+\des+ tsurugidb
+DROP SERVER tsurugidb;
+
+--- Test case: CREATE SERVER ... /ALTER SERVER ...
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+\des+ tsurugidb
+
+ALTER SERVER tsurugidb OPTIONS (endpoint 'ipc', dbname 'test_db');
+\des+ tsurugidb
+
+ALTER SERVER tsurugidb OPTIONS (DROP endpoint, DROP dbname);
+\des+ tsurugidb
+
+ALTER SERVER tsurugidb
+  OPTIONS (endpoint 'stream', address '127.0.0.1', port '12345');
+\des+ tsurugidb
+
+ALTER SERVER tsurugidb OPTIONS (DROP endpoint, DROP address, DROP port);
+\des+ tsurugidb
+
+DROP SERVER tsurugidb;
+
+--- Test case: CREATE SERVER ... OPTIONS .../ALTER SERVER ...: IPC
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'ipc', dbname 'test_db');
+\des+ tsurugidb
+
+ALTER SERVER tsurugidb
+  OPTIONS (SET endpoint 'stream', address '127.0.0.1', port '12345', DROP dbname);
+\des+ tsurugidb
+
+ALTER SERVER tsurugidb
+  OPTIONS (SET endpoint 'ipc', dbname 'test_db', DROP address, DROP port);
+\des+ tsurugidb
+
+ALTER SERVER tsurugidb
+  OPTIONS (SET endpoint 'stream', address 'localhost', port '1');
+\des+ tsurugidb
+
+ALTER SERVER tsurugidb OPTIONS (SET endpoint 'ipc', SET dbname 'test_db_2');
+\des+ tsurugidb
+
+DROP SERVER tsurugidb;
+
+--- Test case: CREATE SERVER ... OPTIONS .../ALTER SERVER ...: TCP
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '127.0.0.1', port '12345');
+\des+ tsurugidb
+DROP SERVER tsurugidb;
+
+--- Test case: case sensitivity
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (ENDPOINT 'ipc', DBNAME 'TEST_DB', ADDRESS '127.0.0.1', PORT '12345');
+\des+ tsurugidb
+DROP SERVER tsurugidb;
+
+--- Test teardown: DDL of the PostgreSQL
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+
+--- Basic operations
+---- Test setup: DDL of the Tsurugi
+SELECT tg_execute_ddl('
+  CREATE TABLE fdw_ddl_table (c INTEGER)
+', 'tsurugidb');
+
+---- Test case: INSERT is the first operation
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+
+INSERT INTO fdw_ddl_table VALUES (1), (2);
+SELECT * FROM fdw_ddl_table ORDER BY c;
+UPDATE fdw_ddl_table SET c = c + 10;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+DELETE FROM fdw_ddl_table WHERE c = 11;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+
+---- Test case: SELECT is the first operation
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+
+SELECT * FROM fdw_ddl_table ORDER BY c;
+UPDATE fdw_ddl_table SET c = c - 10;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+DELETE FROM fdw_ddl_table WHERE c = 2;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+INSERT INTO fdw_ddl_table VALUES (3);
+SELECT * FROM fdw_ddl_table ORDER BY c;
+
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+
+---- Test case: UPDATE is the first operation
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+
+UPDATE fdw_ddl_table SET c = c + 20;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+DELETE FROM fdw_ddl_table WHERE c = 23;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+INSERT INTO fdw_ddl_table VALUES (4);
+SELECT * FROM fdw_ddl_table ORDER BY c;
+
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+
+---- Test case: DELETE is the first operation
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+
+DELETE FROM fdw_ddl_table WHERE c = 4;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+INSERT INTO fdw_ddl_table VALUES (5);
+SELECT * FROM fdw_ddl_table ORDER BY c;
+UPDATE fdw_ddl_table SET c = 111;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+DELETE FROM fdw_ddl_table;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+
+---- Test case: INSERT (preparation) is the first operation
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+
+PREPARE fdw_prepare_ins(integer, integer) AS
+  INSERT INTO fdw_ddl_table VALUES ($1), ($2);
+PREPARE fdw_prepare_sel AS SELECT * FROM fdw_ddl_table ORDER BY c;
+PREPARE fdw_prepare_upd(integer) AS UPDATE fdw_ddl_table SET c = c + $1;
+PREPARE fdw_prepare_del(integer) AS DELETE FROM fdw_ddl_table WHERE c = $1;
+
+EXECUTE fdw_prepare_ins(1, 2);
+EXECUTE fdw_prepare_sel;
+EXECUTE fdw_prepare_upd(10);
+EXECUTE fdw_prepare_sel;
+EXECUTE fdw_prepare_del(11);
+EXECUTE fdw_prepare_sel;
+
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+
+---- Test case: SELECT (preparation) is the first operation
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+
+PREPARE fdw_prepare_ins(integer) AS INSERT INTO fdw_ddl_table VALUES ($1);
+PREPARE fdw_prepare_sel AS SELECT * FROM fdw_ddl_table ORDER BY c;
+PREPARE fdw_prepare_upd(integer) AS UPDATE fdw_ddl_table SET c = c + $1;
+PREPARE fdw_prepare_del(integer) AS DELETE FROM fdw_ddl_table WHERE c = $1;
+
+EXECUTE fdw_prepare_sel;
+EXECUTE fdw_prepare_upd(-10);
+EXECUTE fdw_prepare_sel;
+EXECUTE fdw_prepare_del(2);
+EXECUTE fdw_prepare_sel;
+EXECUTE fdw_prepare_ins(3);
+EXECUTE fdw_prepare_sel;
+
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+
+---- Test case: UPDATE (preparation) is the first operation
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+
+PREPARE fdw_prepare_ins(integer) AS INSERT INTO fdw_ddl_table VALUES ($1);
+PREPARE fdw_prepare_sel AS SELECT * FROM fdw_ddl_table ORDER BY c;
+PREPARE fdw_prepare_upd(integer) AS UPDATE fdw_ddl_table SET c = c + $1;
+PREPARE fdw_prepare_del(integer) AS DELETE FROM fdw_ddl_table WHERE c = $1;
+
+EXECUTE fdw_prepare_upd(20);
+EXECUTE fdw_prepare_sel;
+EXECUTE fdw_prepare_del(23);
+EXECUTE fdw_prepare_sel;
+EXECUTE fdw_prepare_ins(4);
+EXECUTE fdw_prepare_sel;
+
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+
+---- Test case: DELETE (preparation) is the first operation
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+
+PREPARE fdw_prepare_ins AS INSERT INTO fdw_ddl_table VALUES (5);
+PREPARE fdw_prepare_sel AS SELECT * FROM fdw_ddl_table ORDER BY c;
+PREPARE fdw_prepare_upd AS UPDATE fdw_ddl_table SET c = 111;
+PREPARE fdw_prepare_del(integer) AS DELETE FROM fdw_ddl_table WHERE c = $1;
+PREPARE fdw_prepare_del_all AS DELETE FROM fdw_ddl_table;
+
+EXECUTE fdw_prepare_del(4);
+EXECUTE fdw_prepare_sel;
+EXECUTE fdw_prepare_ins;
+EXECUTE fdw_prepare_sel;
+EXECUTE fdw_prepare_upd;
+EXECUTE fdw_prepare_sel;
+EXECUTE fdw_prepare_del_all;
+EXECUTE fdw_prepare_sel;
+
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+
+---- Test teardown: DDL of the Tsurugi
+SELECT tg_execute_ddl('DROP TABLE fdw_ddl_table', 'tsurugidb');

--- a/sql/ddl_unhappy.sql
+++ b/sql/ddl_unhappy.sql
@@ -1,25 +1,30 @@
 /* Test case: unhappy path - Data Definition Language */
--- Test setup: DDL of the PostgreSQL
-CREATE DATABASE contrib_regression2;
-\c contrib_regression2
 
--- Test
+-- EXTENSION
+--- Test setup: DDL of the PostgreSQL
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+
+--- Test case: table exists before
 CREATE TABLE tsurugifdw_regressiontest(id INT);
 CREATE EXTENSION tsurugi_fdw;
 \dx tsurugi_fdw
 DROP TABLE tsurugifdw_regressiontest;
 
+--- Test case: table does not exist
 CREATE EXTENSION tsurugi_fdw;
 \dx tsurugi_fdw
-CREATE SERVER IF NOT EXISTS tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
 
+--- Test case: DDL restriction - tsurugi_fdw is enabled
+---- Test setup: DDL of the PostgreSQL
+CREATE SERVER IF NOT EXISTS tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
 CREATE FOREIGN TABLE tsurugifdw_regressiontest(id INT) SERVER tsurugidb;
 SELECT EXISTS (
   SELECT 1 FROM pg_class
     WHERE relname = 'tsurugifdw_regressiontest' AND relkind = 'f'
 );
 
--- error (CREATE TABLE)
+---- CREATE TABLE
 CREATE TABLE t0_create_table(c1 INTEGER NOT NULL);
 SELECT * FROM t0_create_table;
 CREATE TABLE IF NOT EXISTS mytable1 (id INT);
@@ -45,15 +50,17 @@ SELECT * FROM temp_table;
 CREATE LOCAL TEMP TABLE temp_table1 (id iNT);
 SELECT * FROM temp_table1;
 
--- error (CREATE TABLE AS)
+---- CREATE TABLE AS
 CREATE TABLE t1_create_table_as AS SELECT * FROM tsurugifdw_regressiontest;
 SELECT * FROM t1_create_table_as;
 SELECT * INTO t2_create_table_as FROM tsurugifdw_regressiontest;
 SELECT * FROM t2_create_table_as;
 
+--- Test case: DDL restriction - tsurugi_fdw is disabled
+---- Test setup: DDL of the PostgreSQL
 DROP EXTENSION tsurugi_fdw CASCADE;
 
--- Success (CREATE TABLE)
+---- CREATE TABLE
 CREATE TABLE t0_create_table(c1 INTEGER NOT NULL);
 SELECT * FROM t0_create_table;
 CREATE TABLE IF NOT EXISTS mytable1 (id INT);
@@ -79,12 +86,143 @@ SELECT * FROM temp_table;
 CREATE LOCAL TEMP TABLE temp_table1 (id iNT);
 SELECT * FROM temp_table1;
 
--- Success (CREATE TABLE AS)
+---- CREATE TABLE AS
 CREATE TABLE t1_create_table_as AS SELECT * FROM t0_create_table;
 SELECT * FROM t1_create_table_as;
 SELECT * INTO t2_create_table_as FROM t0_create_table;
 SELECT * FROM t2_create_table_as;
 
--- Test teardown: DDL of the PostgreSQL
+--- Test teardown: DDL of the PostgreSQL
 \c contrib_regression
-DROP DATABASE contrib_regression2;
+DROP DATABASE contrib_regression_ddl;
+
+-- SERVER OPTIONS
+--- Test setup: DDL of the Tsurugi
+SELECT tg_execute_ddl('
+  CREATE TABLE fdw_ddl_table (c INTEGER)
+', 'tsurugidb');
+
+--- Test setup: DDL of the PostgreSQL
+CREATE DATABASE contrib_regression_ddl;
+\c contrib_regression_ddl
+CREATE EXTENSION tsurugi_fdw;
+
+--- Test case: option name validation
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (invalid_option 'value');
+
+--- Test case: required options validation
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream');
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '127.0.0.1');
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', port '12345');
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+ALTER SERVER tsurugidb OPTIONS (endpoint 'stream');
+ALTER SERVER tsurugidb OPTIONS (endpoint 'stream', address '127.0.0.1');
+ALTER SERVER tsurugidb OPTIONS (endpoint 'stream', port '12345');
+DROP SERVER tsurugidb;
+
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '127.0.0.1', port '12345');
+ALTER SERVER tsurugidb OPTIONS (DROP address);
+ALTER SERVER tsurugidb OPTIONS (DROP port);
+ALTER SERVER tsurugidb OPTIONS (DROP address, DROP port);
+DROP SERVER tsurugidb;
+
+--- Test case: endpoint option validation
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'invalid_value');
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'IPC');
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'STREAM');
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint ' ipc');
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'ipc ');
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint '');
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint ' ');
+
+--- Test case: dbname option validation
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'ipc', dbname '');
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'ipc', dbname ' ');
+
+--- Test case: address option validation
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '', port '12345');
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address ' ', port '12345');
+
+--- Test case: port option validation
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '127.0.0.1', port '');
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '127.0.0.1', port ' ');
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '127.0.0.1', port '0');
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '127.0.0.1', port 'abc');
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
+  OPTIONS (endpoint 'stream', address '127.0.0.1', port '-1');
+
+--- Test case: dbname option value is incorrect
+---- Test setup: DDL of the PostgreSQL
+CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
+CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
+
+---- correct -> incorrect
+ALTER SERVER tsurugidb OPTIONS (ADD dbname 'incorrect_dbname');
+INSERT INTO fdw_ddl_table VALUES (1);
+UPDATE fdw_ddl_table SET c = c + 10;
+DELETE FROM fdw_ddl_table;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+
+---- incorrect -> correct
+ALTER SERVER tsurugidb OPTIONS (DROP dbname);
+INSERT INTO fdw_ddl_table VALUES (2);
+SELECT * FROM fdw_ddl_table ORDER BY c;
+UPDATE fdw_ddl_table SET c = c + 20;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+DELETE FROM fdw_ddl_table;
+SELECT * FROM fdw_ddl_table ORDER BY c;
+
+---- Test setup: PREPARE statements
+PREPARE fdw_prepare_ins(integer) AS INSERT INTO fdw_ddl_table VALUES ($1);
+PREPARE fdw_prepare_upd(integer) AS UPDATE fdw_ddl_table SET c = c + $1;
+PREPARE fdw_prepare_del AS DELETE FROM fdw_ddl_table;
+PREPARE fdw_prepare_sel AS SELECT * FROM fdw_ddl_table ORDER BY c;
+
+---- correct -> incorrect (preparation)
+ALTER SERVER tsurugidb OPTIONS (ADD dbname 'incorrect_dbname');
+EXECUTE fdw_prepare_ins(1);
+EXECUTE fdw_prepare_upd(10);
+EXECUTE fdw_prepare_del;
+EXECUTE fdw_prepare_sel;
+
+---- incorrect -> correct (preparation)
+ALTER SERVER tsurugidb OPTIONS (SET dbname 'tsurugi');
+EXECUTE fdw_prepare_ins(2);
+EXECUTE fdw_prepare_sel;
+EXECUTE fdw_prepare_upd(20);
+EXECUTE fdw_prepare_sel;
+EXECUTE fdw_prepare_del;
+EXECUTE fdw_prepare_sel;
+
+---- Test teardown: PREPARE statements
+DEALLOCATE fdw_prepare_ins;
+DEALLOCATE fdw_prepare_sel;
+DEALLOCATE fdw_prepare_upd;
+DEALLOCATE fdw_prepare_del;
+
+--- Test teardown: DDL of the PostgreSQL
+\c contrib_regression
+DROP DATABASE contrib_regression_ddl;
+
+--- Test teardown: DDL of the Tsurugi
+SELECT tg_execute_ddl('DROP TABLE fdw_ddl_table', 'tsurugidb');

--- a/sql/test_cleanup.sql
+++ b/sql/test_cleanup.sql
@@ -1,4 +1,5 @@
 SELECT tg_execute_ddl('DROP TABLE IF EXISTS fdw_case_table', 'tsurugidb');
+SELECT tg_execute_ddl('DROP TABLE IF EXISTS fdw_ddl_table', 'tsurugidb');
 SELECT tg_execute_ddl('DROP TABLE IF EXISTS fdw_del_variation_table', 'tsurugidb');
 SELECT tg_execute_ddl('DROP TABLE IF EXISTS fdw_del_variation_table_1', 'tsurugidb');
 SELECT tg_execute_ddl('DROP TABLE IF EXISTS fdw_del_variation_table_2', 'tsurugidb');

--- a/src/common/connection.cpp
+++ b/src/common/connection.cpp
@@ -101,13 +101,6 @@ void handle_remote_xact(ForeignServer *server)
 									  tsurugifdw_inval_callback, (Datum) 0);
 	}
 
-	/* Initializing connection to tsurugi server. */
-	auto error = Tsurugi::init(server->serverid);
-	if (error != ERROR_CODE::OK) {
-		ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
-						errmsg("%s", Tsurugi::get_error_message(error).c_str())));
-	}
-
 	/* Set flag that we did GetConnection during the current transaction */
 	xact_got_connection = true;
 

--- a/src/common/connection.cpp
+++ b/src/common/connection.cpp
@@ -130,7 +130,8 @@ void begin_remote_xact(ConnCacheEntry *entry)
 	/* Start main transaction if we haven't yet */
 	if (entry->xact_depth <= 0)
 	{
-		ERROR_CODE error = Tsurugi::start_transaction();
+		auto server_oid = entry->key;
+		ERROR_CODE error = Tsurugi::start_transaction(server_oid);
 		if (error != ERROR_CODE::OK)
 		{
 			elog(ERROR, "Failed to begin the Tsurugi transaction. (%d)\n%s", 

--- a/src/fdw/tsurugi_fdw.cpp
+++ b/src/fdw/tsurugi_fdw.cpp
@@ -1264,11 +1264,14 @@ tsurugiBeginForeignScan(ForeignScanState* node, int eflags)
 	table = GetForeignTable(rte->relid);
 	server = GetForeignServer(table->serverid);
 
-	/* Initializing connection to tsurugi server. */
-	auto error = Tsurugi::init(server->serverid);
-	if (error != ERROR_CODE::OK) {
-		ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
-						errmsg("%s", Tsurugi::get_error_message(error).c_str())));
+	if (!Tsurugi::is_initialized(server->serverid))
+	{
+		/* Initializing connection to tsurugi server. */
+		auto error = Tsurugi::init(server->serverid);
+		if (error != ERROR_CODE::OK) {
+			ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
+							errmsg("%s", Tsurugi::get_error_message(error).c_str())));
+		}
 	}
 
 	handle_remote_xact(server);
@@ -1702,11 +1705,14 @@ tsurugiBeginDirectModify(ForeignScanState* node, int eflags)
 	table = GetForeignTable(rte->relid);
 	server = GetForeignServer(table->serverid);
 
-	/* Initializing connection to tsurugi server. */
-	auto error = Tsurugi::init(server->serverid);
-	if (error != ERROR_CODE::OK) {
-		ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
-						errmsg("%s", Tsurugi::get_error_message(error).c_str())));
+	if (!Tsurugi::is_initialized(server->serverid))
+	{
+		/* Initializing connection to tsurugi server. */
+		auto error = Tsurugi::init(server->serverid);
+		if (error != ERROR_CODE::OK) {
+			ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
+							errmsg("%s", Tsurugi::get_error_message(error).c_str())));
+		}
 	}
 
 #ifdef __TSURUGI_PLANNER__
@@ -2242,11 +2248,14 @@ static List* tsurugiImportForeignSchema(ImportForeignSchemaStmt* stmt, Oid serve
 	elog(DEBUG2, "ForeignServer::serverid: %u", server->serverid);
 	elog(DEBUG2, R"(ForeignServer::servername: "%s")", server->servername);
 
-	/* Initializing connection to tsurugi server. */
-	error = Tsurugi::init(server->serverid);
-	if (error != ERROR_CODE::OK) {
-		ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
-						errmsg("%s", Tsurugi::get_error_message(error).c_str())));
+	if (!Tsurugi::is_initialized(server->serverid))
+	{
+		/* Initializing connection to tsurugi server. */
+		error = Tsurugi::init(server->serverid);
+		if (error != ERROR_CODE::OK) {
+			ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
+							errmsg("%s", Tsurugi::get_error_message(error).c_str())));
+		}
 	}
 
 	TableListPtr tg_table_list;

--- a/src/fdw/tsurugi_options.cpp
+++ b/src/fdw/tsurugi_options.cpp
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2025 Project Tsurugi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Portions Copyright (c) 1996-2023, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, The Regents of the University of California
+ *
+ *	@file tsurugi_fdw_option.cpp
+ *	@brief Tsurugi server options.
+ */
+
+#include <algorithm>
+#include <charconv>
+#include <string>
+#include <unordered_map>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "postgres.h"
+
+#include "access/reloptions.h"
+#include "catalog/pg_foreign_server.h"
+#include "foreign/fdwapi.h"
+
+PG_FUNCTION_INFO_V1(tsurugi_fdw_validator);
+
+#ifdef __cplusplus
+}
+#endif
+
+/* Defines for valid option names */
+static constexpr const char* const kOptNameEndpoint = "endpoint";
+static constexpr const char* const kOptNameDbname = "dbname";
+static constexpr const char* const kOptNameAddress = "address";
+static constexpr const char* const kOptNamePort = "port";
+
+/* Defines for endpoint values. */
+static constexpr const char* const kValEndpointIpc = "ipc";
+static constexpr const char* const kValEndpointTcp = "stream";
+
+/**
+ * Describes the valid options for objects that use this wrapper.
+ */
+struct TsurugiFdwOption
+{
+	std::string name; // Option name
+	Oid context; // Oid of catalog in which option may appear
+};
+
+/**
+ * Valid options for tsurugi_fdw.
+ */
+static const std::unordered_multimap<std::string_view, Oid> valid_options =
+{
+	/* Foreign server options */
+	{kOptNameEndpoint, ForeignServerRelationId},
+	{kOptNameDbname, ForeignServerRelationId},
+	{kOptNameAddress, ForeignServerRelationId},
+	{kOptNamePort, ForeignServerRelationId},
+};
+
+static bool is_valid_option(std::string_view option, Oid context);
+
+/**
+ * Validate the generic options given to a FOREIGN DATA WRAPPER, SERVER,
+ * USER MAPPING or FOREIGN TABLE that uses tsurugi_fdw.
+ *
+ * Raise an ERROR if the option or its value is considered invalid.
+ */
+Datum
+tsurugi_fdw_validator(PG_FUNCTION_ARGS)
+{
+	List* options_list = untransformRelOptions(PG_GETARG_DATUM(0));
+	Oid catalog = PG_GETARG_OID(1);
+
+	elog(DEBUG2, "tsurugi_fdw : %s(%d)", __func__, catalog);
+
+	std::string opt_val_endpoint;
+	std::string opt_val_dbname;
+	std::string opt_val_address;
+	std::string opt_val_port;
+
+	ListCell* cell;
+	foreach (cell, options_list) {
+		DefElem* def = (DefElem*)lfirst(cell);
+
+		auto opt_key = std::string(def->defname);
+		auto opt_val = std::string(strVal(def->arg));
+
+		/* Convert the option name to lowercase. */
+		std::transform(opt_key.begin(), opt_key.end(), opt_key.begin(),
+					   [](unsigned char c) { return std::tolower(c); });
+
+		/* Check whether the option name is valid. */
+		if (!is_valid_option(opt_key, catalog)) {
+			ereport(ERROR, (errcode(ERRCODE_FDW_INVALID_OPTION_NAME),
+							errmsg(R"_(invalid option "%s")_", def->defname)));
+		}
+
+		/* Trim spaces from both ends of the option value. */
+		auto it_s =
+			std::find_if_not(opt_val.begin(), opt_val.end(), [](unsigned char ch) {
+				return std::isspace(ch);
+			});
+		auto it_e =
+			std::find_if_not(opt_val.rbegin(), opt_val.rend(), [](unsigned char ch) {
+						 return std::isspace(ch);
+			}).base();
+
+		/* If it consists only of spaces, it is treated as an empty string. */
+		if (it_s >= it_e) {
+			opt_val.clear();
+		} 
+
+		/* Validate option values. */
+		if (opt_val.empty()) {
+			ereport(ERROR, (errcode(ERRCODE_FDW_INVALID_ATTRIBUTE_VALUE),
+							errmsg(R"(option "%s" requires a non-empty value)", opt_key.c_str())));
+		}
+
+		/* Option value validation and storage. */
+		if (opt_key == kOptNameEndpoint) {
+			/* The value of the "endpoint" option must be either "ipc" or "stream". */
+			if ((opt_val != kValEndpointIpc) && (opt_val != kValEndpointTcp)) {
+				ereport(ERROR,
+						(errcode(ERRCODE_FDW_INVALID_ATTRIBUTE_VALUE),
+						 errmsg(R"(invalid value ("%s") for option "%s")", opt_val.c_str(),
+								kOptNameEndpoint),
+						 errdetail("expected '%s' or '%s'", kValEndpointIpc, kValEndpointTcp)));
+			}
+			opt_val_endpoint = opt_val;
+
+		} else if (opt_key == kOptNameDbname) {
+			opt_val_dbname = opt_val;
+
+		} else if (opt_key == kOptNameAddress) {
+			opt_val_address = opt_val;
+
+		} else if (opt_key == kOptNamePort) {
+			/* The value of the "port" option must be an integer greater than zero. */
+			int port_num;
+			auto begin = opt_val.data();
+			auto end = begin + opt_val.size();
+			auto [pos, ec] = std::from_chars(begin, end, port_num);
+
+			if ((ec != std::errc{}) || (pos != end) || (port_num <= 0)) {
+				ereport(ERROR, (errcode(ERRCODE_FDW_INVALID_ATTRIBUTE_VALUE),
+								errmsg(R"("%s" must be an integer value greater than zero: %s)",
+									   def->defname, opt_val.c_str())));
+			}
+			opt_val_port = opt_val;
+		}
+	}
+
+	/* Validate required options. */
+	if (catalog == ForeignServerRelationId) {
+		/* For foreign server options. */
+		if (opt_val_endpoint == kValEndpointIpc) {
+			if (opt_val_dbname.empty()) {
+				elog(LOG, R"(The default value is used for "%s".)", kOptNameDbname);
+			}
+		} else if (opt_val_endpoint == kValEndpointTcp) {
+			/* The "address" and "port" options are required for TCP connection. */
+			if (opt_val_address.empty()) {
+				ereport(ERROR, (errcode(ERRCODE_FDW_OPTION_NAME_NOT_FOUND),
+								errmsg(R"(missing required option "%s")", kOptNameAddress)));
+			} else if (opt_val_port.empty()) {
+				ereport(ERROR, (errcode(ERRCODE_FDW_OPTION_NAME_NOT_FOUND),
+								errmsg(R"(missing required option "%s")", kOptNamePort)));
+			}
+		}
+
+		elog(DEBUG2, "Foreign server options: %s:=[%s], %s:=[%s], %s:=[%s], %s:=[%s]",
+				kOptNameEndpoint, opt_val_endpoint.c_str(),
+				kOptNameDbname, opt_val_dbname.c_str(),
+				kOptNameAddress, opt_val_address.c_str(),
+				kOptNamePort, opt_val_port.c_str());
+	}
+
+	PG_RETURN_VOID();
+}
+
+/**
+ * @brief Check if the provided option is one of the valid options.
+ * @param option The option name to check.
+ * @param context The Oid of the catalog holding the object the option is for.
+ * @retval true if the option is valid.
+ * @retval false if the option is not valid.
+ */
+static bool is_valid_option(std::string_view option, Oid context)
+{
+	auto range = valid_options.equal_range(option);
+	for (auto it = range.first; it != range.second; ++it) {
+		if (it->second == context) {
+			return true;
+		}
+	}
+	return false;
+}

--- a/src/fdw/tsurugi_utils.cpp
+++ b/src/fdw/tsurugi_utils.cpp
@@ -60,6 +60,7 @@ static std::pair<std::string, std::string> make_prepare_statement(const char* qu
 static ogawayama::stub::placeholders_type make_placeholders(ParamListInfo param_linfo);
 static ogawayama::stub::parameters_type bind_parameters(ParamListInfo param_linfo);
 static std::pair<std::string, std::string> tsurugi_prepare_wrapper(
+                                                Oid server_oid,
                                                 const char* query, 
                                                 ParamListInfo param_linfo);
 #endif
@@ -355,12 +356,14 @@ make_placeholders(List* fdw_exprs)
 #ifdef __TSURUGI_PLANNER__
 /**
  *  @brief  Prepare a statement to tsurugidb.
+ *  @param  (server_oid) oid of tsurugi server.
  *  @param  (query) original query.
  *  @return	(first)     prepare name.
  *          (second)    prepare statement.
  */
 static std::pair<std::string, std::string>
-tsurugi_prepare_wrapper(const char* query, 
+tsurugi_prepare_wrapper(Oid server_oid,
+                        const char* query,
                         ParamListInfo param_linfo)
 {
  	elog(DEBUG3, "tsurugi_fdw : %s", __func__);
@@ -368,7 +371,7 @@ tsurugi_prepare_wrapper(const char* query,
     auto prep = make_prepare_statement(query);
     auto placeholders = make_placeholders(param_linfo);
     auto prep_stmt = make_tsurugi_query(prep.second);
-	ERROR_CODE error = Tsurugi::prepare(prep_stmt, placeholders);
+	ERROR_CODE error = Tsurugi::prepare(server_oid, prep_stmt, placeholders);
 	if (error != ERROR_CODE::OK)
 	{
 		Tsurugi::report_error("Failed to prepare the statement to Tsurugi.", 
@@ -379,8 +382,9 @@ tsurugi_prepare_wrapper(const char* query,
 }
 #else
 static std::pair<std::string, std::string>
-tsurugi_prepare_wrapper(const char* query, 
-                        PlanState* node, 
+tsurugi_prepare_wrapper(Oid server_oid,
+                        const char* query,
+                        PlanState* node,
                         List* fdw_exprs)
 {
  	elog(DEBUG3, "tsurugi_fdw : %s", __func__);
@@ -388,7 +392,7 @@ tsurugi_prepare_wrapper(const char* query,
     auto prep = make_prepare_statement(query);
     auto placeholders = make_placeholders(fdw_exprs);
     auto prep_stmt = make_tsurugi_query(prep.second);
-	ERROR_CODE error = Tsurugi::prepare(prep_stmt, placeholders);
+	ERROR_CODE error = Tsurugi::prepare(server_oid, prep_stmt, placeholders);
 	if (error != ERROR_CODE::OK)
 	{
 		Tsurugi::report_error("Failed to prepare the statement to Tsurugi.", 
@@ -501,8 +505,10 @@ create_cursor(ForeignScanState* node)
 	TgFdwForeignScanState* fsstate = (TgFdwForeignScanState*) node->fdw_state;
     if (is_prepare_statement(fsstate->query_string))
     {
+        ForeignTable *ft = GetForeignTable(fsstate->rel->rd_id);
         // Prepare the statement.
-        auto prep = tsurugi_prepare_wrapper(fsstate->query_string,
+        auto prep = tsurugi_prepare_wrapper(ft->serverid,
+                                            fsstate->query_string,
                                             fsstate->param_linfo);
         // Execute the prepared statement.
         auto params = bind_parameters(fsstate->param_linfo);
@@ -514,7 +520,7 @@ create_cursor(ForeignScanState* node)
         {
             Tsurugi::report_error("Failed to execute the statement on Tsurugi.", 
                                     error, prep.second);
-        }           
+        }
     }
     else
     {
@@ -545,8 +551,10 @@ create_cursor(ForeignScanState* node)
     ForeignScan* fsplan = (ForeignScan*) node->ss.ps.plan;
     if (fsstate->numParams > 0)
     {
+        ForeignTable *ft = GetForeignTable(fsstate->rel->rd_id);
         // Prepare the statement.
-        auto prep = tsurugi_prepare_wrapper(fsstate->query_string, 
+        auto prep = tsurugi_prepare_wrapper(ft->serverid,
+                                            fsstate->query_string, 
                                             (PlanState *) node,
                                             fsplan->fdw_exprs);
         // Execute the prepared statement.
@@ -597,7 +605,7 @@ prepare_direct_modify(TgFdwDirectModifyState* dmstate)
 	auto placeholders = make_placeholders(param_linfo);
 	auto prep_stmt = make_tsurugi_query(prep.second);
 
-	ERROR_CODE error = Tsurugi::prepare(prep_stmt, placeholders);
+	ERROR_CODE error = Tsurugi::prepare(dmstate->server->serverid, prep_stmt, placeholders);
 	if (error != ERROR_CODE::OK)
 	{
 		Tsurugi::report_error("Failed to prepare the statement to Tsurugi.", 
@@ -645,7 +653,7 @@ prepare_direct_modify(TgFdwDirectModifyState* dmstate, List* fdw_exprs)
 	}
 
     std::string prep_stmt = make_tsurugi_query(dmstate->query);
-	ERROR_CODE error = Tsurugi::prepare(prep_stmt, placeholders);
+	ERROR_CODE error = Tsurugi::prepare(dmstate->server->serverid, prep_stmt, placeholders);
 	if (error != ERROR_CODE::OK)
 	{
 		Tsurugi::report_error("Failed to prepare the statement on Tsurugi.", 
@@ -767,7 +775,8 @@ prepare_foreign_modify(TgFdwForeignModifyState *fmstate)
                                 Tsurugi::get_tg_column_type(tupdesc->attrs[i].atttypid));
 	}
 
-	ERROR_CODE error = Tsurugi::prepare(fmstate->query, placeholders);
+	ForeignTable *ft = GetForeignTable(fmstate->rel->rd_id);
+	ERROR_CODE error = Tsurugi::prepare(ft->serverid, fmstate->query, placeholders);
 	if (error != ERROR_CODE::OK)
 	{
 		Tsurugi::report_error("Failed to prepare the statement on Tsurugi.", 

--- a/src/fdw/tsurugi_utils.cpp
+++ b/src/fdw/tsurugi_utils.cpp
@@ -597,15 +597,7 @@ prepare_direct_modify(TgFdwDirectModifyState* dmstate)
 	auto placeholders = make_placeholders(param_linfo);
 	auto prep_stmt = make_tsurugi_query(prep.second);
 
-	/* Initializing connection to tsurugi server. */
-	auto error = Tsurugi::init(dmstate->server->serverid);
-	if (error != ERROR_CODE::OK)
-	{
-		ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
-						errmsg("%s", Tsurugi::get_error_message(error).c_str())));
-	}
-
-	error = Tsurugi::prepare(prep_stmt, placeholders);
+	ERROR_CODE error = Tsurugi::prepare(prep_stmt, placeholders);
 	if (error != ERROR_CODE::OK)
 	{
 		Tsurugi::report_error("Failed to prepare the statement to Tsurugi.", 

--- a/src/udf/tg_execute_ddl.cpp
+++ b/src/udf/tg_execute_ddl.cpp
@@ -109,11 +109,13 @@ tg_execute_ddl(PG_FUNCTION_ARGS)
 
 	ERROR_CODE error = ERROR_CODE::UNKNOWN;
 
-	/* Initializing connection to tsurugi server. */
-	error = Tsurugi::init(server_oid);
-	if (error != ERROR_CODE::OK) {
-		ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
-						errmsg("%s", Tsurugi::get_error_message(error).c_str())));
+	if (!Tsurugi::is_initialized(server_oid)) {
+		/* Initializing connection to tsurugi server. */
+		error = Tsurugi::init(server_oid);
+		if (error != ERROR_CODE::OK) {
+			ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
+							errmsg("%s", Tsurugi::get_error_message(error).c_str())));
+		}
 	}
 
 	error = Tsurugi::start_transaction();

--- a/src/udf/tg_execute_ddl.cpp
+++ b/src/udf/tg_execute_ddl.cpp
@@ -33,6 +33,8 @@ extern "C" {
 /* Primary include file for PostgreSQL (first file to be included). */
 #include "postgres.h"
 /* Related include files for PostgreSQL. */
+#include "access/htup_details.h"
+#include "catalog/pg_foreign_server.h"
 #include "utils/builtins.h"
 #include "utils/syscache.h"
 
@@ -87,6 +89,7 @@ tg_execute_ddl(PG_FUNCTION_ARGS)
 						errmsg(R"("%s" is not supported)", arg_ddl_statement.c_str())));
 	}
 
+	Oid server_oid = InvalidOid;
 	/* Get the Tsurugi server OID. */
 	HeapTuple srv_tuple =
 		SearchSysCache1(FOREIGNSERVERNAME, CStringGetDatum(arg_server_name.c_str()));
@@ -94,6 +97,7 @@ tg_execute_ddl(PG_FUNCTION_ARGS)
 		ereport(ERROR, (errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
 						errmsg(R"(server "%s" does not exist)", arg_server_name.c_str())));
 	}
+	server_oid = ((Form_pg_foreign_server)GETSTRUCT(srv_tuple))->oid;
 	ReleaseSysCache(srv_tuple);
 
 	std::stringstream debug_log;
@@ -105,9 +109,10 @@ tg_execute_ddl(PG_FUNCTION_ARGS)
 
 	ERROR_CODE error = ERROR_CODE::UNKNOWN;
 
-	error = Tsurugi::init();
+	/* Initializing connection to tsurugi server. */
+	error = Tsurugi::init(server_oid);
 	if (error != ERROR_CODE::OK) {
-		ereport(ERROR, (errcode(ERRCODE_FDW_UNABLE_TO_CREATE_REPLY),
+		ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
 						errmsg("%s", Tsurugi::get_error_message(error).c_str())));
 	}
 

--- a/src/udf/tg_execute_ddl.cpp
+++ b/src/udf/tg_execute_ddl.cpp
@@ -109,16 +109,7 @@ tg_execute_ddl(PG_FUNCTION_ARGS)
 
 	ERROR_CODE error = ERROR_CODE::UNKNOWN;
 
-	if (!Tsurugi::is_initialized(server_oid)) {
-		/* Initializing connection to tsurugi server. */
-		error = Tsurugi::init(server_oid);
-		if (error != ERROR_CODE::OK) {
-			ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
-							errmsg("%s", Tsurugi::get_error_message(error).c_str())));
-		}
-	}
-
-	error = Tsurugi::start_transaction();
+	error = Tsurugi::start_transaction(server_oid);
 	if (error != ERROR_CODE::OK) {
 		ereport(ERROR, (errcode(ERRCODE_FDW_UNABLE_TO_CREATE_REPLY),
 						errmsg("%s", Tsurugi::get_error_message(error).c_str())));

--- a/src/udf/tg_show_tables.cpp
+++ b/src/udf/tg_show_tables.cpp
@@ -39,7 +39,9 @@ extern "C" {
 /* Primary include file for PostgreSQL (first file to be included). */
 #include "postgres.h"
 /* Related include files for PostgreSQL. */
+#include "access/htup_details.h"
 #include "catalog/namespace.h"
+#include "catalog/pg_foreign_server.h"
 #include "utils/builtins.h"
 #include "utils/syscache.h"
 
@@ -111,14 +113,15 @@ tg_show_tables(PG_FUNCTION_ARGS)
 						errdetail("expected true or false")));
 	}
 
+	Oid server_oid = InvalidOid;
 	/* Get the Tsurugi server OID. */
 	HeapTuple srv_tuple =
 		SearchSysCache1(FOREIGNSERVERNAME, CStringGetDatum(arg_server_name.c_str()));
 	if (!HeapTupleIsValid(srv_tuple)) {
-		ereport(ERROR,
-			(errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
-			errmsg(R"(server "%s" does not exist)", arg_server_name.c_str())));
+		ereport(ERROR, (errcode(ERRCODE_FDW_UNABLE_TO_ESTABLISH_CONNECTION),
+						errmsg(R"(server "%s" does not exist)", arg_server_name.c_str())));
 	}
+	server_oid = ((Form_pg_foreign_server)GETSTRUCT(srv_tuple))->oid;
 	ReleaseSysCache(srv_tuple);
 
 	std::stringstream debug_log;
@@ -132,6 +135,13 @@ tg_show_tables(PG_FUNCTION_ARGS)
 
 	ERROR_CODE error;
 	TableListPtr tg_table_list;
+
+	/* Initializing connection to tsurugi server. */
+	error = Tsurugi::init(server_oid);
+	if (error != ERROR_CODE::OK) {
+		ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
+						errmsg("%s", Tsurugi::get_error_message(error).c_str())));
+	}
 
 	/* Get a list of table names from Tsurugi. */
 	error = Tsurugi::get_list_tables(tg_table_list);

--- a/src/udf/tg_show_tables.cpp
+++ b/src/udf/tg_show_tables.cpp
@@ -136,11 +136,13 @@ tg_show_tables(PG_FUNCTION_ARGS)
 	ERROR_CODE error;
 	TableListPtr tg_table_list;
 
-	/* Initializing connection to tsurugi server. */
-	error = Tsurugi::init(server_oid);
-	if (error != ERROR_CODE::OK) {
-		ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
-						errmsg("%s", Tsurugi::get_error_message(error).c_str())));
+	if (!Tsurugi::is_initialized(server_oid)) {
+		/* Initializing connection to tsurugi server. */
+		error = Tsurugi::init(server_oid);
+		if (error != ERROR_CODE::OK) {
+			ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
+							errmsg("%s", Tsurugi::get_error_message(error).c_str())));
+		}
 	}
 
 	/* Get a list of table names from Tsurugi. */

--- a/src/udf/tg_show_tables.cpp
+++ b/src/udf/tg_show_tables.cpp
@@ -136,17 +136,8 @@ tg_show_tables(PG_FUNCTION_ARGS)
 	ERROR_CODE error;
 	TableListPtr tg_table_list;
 
-	if (!Tsurugi::is_initialized(server_oid)) {
-		/* Initializing connection to tsurugi server. */
-		error = Tsurugi::init(server_oid);
-		if (error != ERROR_CODE::OK) {
-			ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
-							errmsg("%s", Tsurugi::get_error_message(error).c_str())));
-		}
-	}
-
 	/* Get a list of table names from Tsurugi. */
-	error = Tsurugi::get_list_tables(tg_table_list);
+	error = Tsurugi::get_list_tables(server_oid, tg_table_list);
 	if (error != ERROR_CODE::OK) {
 		ereport(ERROR,
 			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_REPLY),

--- a/src/udf/tg_verify_tables.cpp
+++ b/src/udf/tg_verify_tables.cpp
@@ -163,17 +163,8 @@ tg_verify_tables(PG_FUNCTION_ARGS)
 	ERROR_CODE error;
 	TableListPtr tg_table_list;
 
-	if (!Tsurugi::is_initialized(server_oid)) {
-		/* Initializing connection to tsurugi server. */
-		error = Tsurugi::init(server_oid);
-		if (error != ERROR_CODE::OK) {
-			ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
-							errmsg("%s", Tsurugi::get_error_message(error).c_str())));
-		}
-	}
-
 	/* Get a list of table names from Tsurugi. */
-	error = Tsurugi::get_list_tables(tg_table_list);
+	error = Tsurugi::get_list_tables(server_oid, tg_table_list);
 	if (error != ERROR_CODE::OK) {
 		ereport(ERROR, (errcode(ERRCODE_FDW_UNABLE_TO_CREATE_REPLY),
 						errmsg("Failed to retrieve table list from Tsurugi. (error: %d)",
@@ -303,7 +294,7 @@ tg_verify_tables(PG_FUNCTION_ARGS)
 
 		TableMetadataPtr tsurugi_table_metadata;
 		/* Get table metadata from Tsurugi. */
-		error = Tsurugi::get_table_metadata(table_name, tsurugi_table_metadata);
+		error = Tsurugi::get_table_metadata(server_oid, table_name, tsurugi_table_metadata);
 		if (error != ERROR_CODE::OK) {
 			ereport(ERROR, (errcode(ERRCODE_FDW_UNABLE_TO_CREATE_REPLY),
 							errmsg("Failed to retrieve table metadata from Tsurugi. (error: %d)",

--- a/src/udf/tg_verify_tables.cpp
+++ b/src/udf/tg_verify_tables.cpp
@@ -163,11 +163,13 @@ tg_verify_tables(PG_FUNCTION_ARGS)
 	ERROR_CODE error;
 	TableListPtr tg_table_list;
 
-	/* Initializing connection to tsurugi server. */
-	error = Tsurugi::init(server_oid);
-	if (error != ERROR_CODE::OK) {
-		ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
-						errmsg("%s", Tsurugi::get_error_message(error).c_str())));
+	if (!Tsurugi::is_initialized(server_oid)) {
+		/* Initializing connection to tsurugi server. */
+		error = Tsurugi::init(server_oid);
+		if (error != ERROR_CODE::OK) {
+			ereport(ERROR, (errcode(ERRCODE_FDW_ERROR),
+							errmsg("%s", Tsurugi::get_error_message(error).c_str())));
+		}
 	}
 
 	/* Get a list of table names from Tsurugi. */

--- a/tsurugi_fdw--1.2.0--1.3.0.sql
+++ b/tsurugi_fdw--1.2.0--1.3.0.sql
@@ -1,3 +1,10 @@
+CREATE OR REPLACE FUNCTION tsurugi_fdw_validator(text[], oid)
+  RETURNS void AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
+ALTER FOREIGN DATA WRAPPER tsurugi_fdw
+  VALIDATOR tsurugi_fdw_validator;
+
 CREATE OR REPLACE FUNCTION tg_show_tables
   (text DEFAULT null, text DEFAULT null, text DEFAULT 'detail', boolean DEFAULT true)
   RETURNS JSON AS 'tsurugi_fdw' LANGUAGE C;

--- a/tsurugi_fdw--1.2.0--1.3.0.sql
+++ b/tsurugi_fdw--1.2.0--1.3.0.sql
@@ -1,0 +1,3 @@
+CREATE OR REPLACE FUNCTION tg_show_tables
+  (text DEFAULT null, text DEFAULT null, text DEFAULT 'detail', boolean DEFAULT true)
+  RETURNS JSON AS 'tsurugi_fdw' LANGUAGE C;

--- a/tsurugi_fdw--1.3.0.sql
+++ b/tsurugi_fdw--1.3.0.sql
@@ -30,7 +30,7 @@ CREATE FUNCTION tg_show_transaction() RETURNS cstring
   AS 'tsurugi_fdw' LANGUAGE C STRICT;
 
 CREATE FUNCTION tg_show_tables
-  (text DEFAULT null, text DEFAULT null, text DEFAULT 'summary', boolean DEFAULT true)
+  (text DEFAULT null, text DEFAULT null, text DEFAULT 'detail', boolean DEFAULT true)
   RETURNS JSON AS 'tsurugi_fdw' LANGUAGE C;
 
 CREATE FUNCTION tg_verify_tables

--- a/tsurugi_fdw--1.3.0.sql
+++ b/tsurugi_fdw--1.3.0.sql
@@ -1,12 +1,17 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION tsurugi_fdw" to load this file. \quit
 
-CREATE FUNCTION tsurugi_fdw_handler() 
+CREATE FUNCTION tsurugi_fdw_handler()
   RETURNS fdw_handler AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT;
 
+CREATE FUNCTION tsurugi_fdw_validator(options text[], catalog oid)
+  RETURNS void AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;
+
 CREATE FOREIGN DATA WRAPPER tsurugi_fdw
-  HANDLER tsurugi_fdw_handler;
+  HANDLER tsurugi_fdw_handler
+  VALIDATOR tsurugi_fdw_validator;
 
 CREATE FUNCTION tg_set_transaction(text, text, text) RETURNS cstring
   AS 'tsurugi_fdw' LANGUAGE C STRICT;


### PR DESCRIPTION
Includes the following additions and changes:
- Added functionality to set the Tsurugi database name.
- The default value of the user-defined function tg_show_tables() has changed.

## Regression Testing

- **PostgreSQL 12.22**

  ```shell-session
  $ make USE_PGXS=1 tests
  bash ./scripts/test.sh
  make[1]: Entering directory '/home/postgres/.local/src/tsurugi_fdw/feature-tg_dbname'
  /usr/local/postgres/12.22/lib/pgxs/src/makefiles/../../src/test/regress/pg_regress --inputdir=./ --bindir='/usr/local/postgres/12.22/bin'    --dbname=contrib_regression test_preparation ddl_happy dml_happy data_types_happy case_sensitive_happy prep_dml_happy prep_data_types_happy prep_case_sensitive_happy manual_tutorial udf_transaction_happy udf_tg_show_tables_happy udf_tg_verify_tables_happy import_foreign_schema_happy ddl_unhappy dml_unhappy data_types_unhappy case_sensitive_unhappy prep_dml_unhappy prep_data_types_unhappy prep_case_sensitive_unhappy udf_tg_show_tables_unhappy udf_tg_show_tables_extra udf_tg_verify_tables_unhappy udf_tg_verify_tables_extra udf_transaction_unhappy import_foreign_schema_unhappy import_foreign_schema_extra dml_unhappy_pg12 prep_dml_unhappy_pg12
  (using postmaster on Unix socket, port 5421)
  pg_regress: could not set core size: disallowed by hard limit
  ============== dropping database "contrib_regression" ==============
  DROP DATABASE
  ============== creating database "contrib_regression" ==============
  CREATE DATABASE
  ALTER DATABASE
  ============== running regression test queries        ==============
  test test_preparation             ... ok           14 ms
  test ddl_happy                    ... ok         6264 ms
  test dml_happy                    ... ok         3538 ms
  test data_types_happy             ... ok         6633 ms
  test case_sensitive_happy         ... ok          227 ms
  test prep_dml_happy               ... ok         5095 ms
  test prep_data_types_happy        ... ok         8126 ms
  test prep_case_sensitive_happy    ... ok          426 ms
  test manual_tutorial              ... ok          296 ms
  test udf_transaction_happy        ... ok         1174 ms
  test udf_tg_show_tables_happy     ... ok         3246 ms
  test udf_tg_verify_tables_happy   ... ok         4925 ms
  test import_foreign_schema_happy  ... ok         2965 ms
  test ddl_unhappy                  ... ok         6456 ms
  test dml_unhappy                  ... ok          505 ms
  test data_types_unhappy           ... ok         2729 ms
  test case_sensitive_unhappy       ... ok           79 ms
  test prep_dml_unhappy             ... ok          325 ms
  test prep_data_types_unhappy      ... ok         1569 ms
  test prep_case_sensitive_unhappy  ... ok           82 ms
  test udf_tg_show_tables_unhappy   ... ok          324 ms
  test udf_tg_show_tables_extra     ... ok         4622 ms
  test udf_tg_verify_tables_unhappy ... ok            8 ms
  test udf_tg_verify_tables_extra   ... ok        10575 ms
  test udf_transaction_unhappy      ... ok          707 ms
  test import_foreign_schema_unhappy ... ok            5 ms
  test import_foreign_schema_extra  ... ok         8978 ms
  test dml_unhappy_pg12             ... ok           80 ms
  test prep_dml_unhappy_pg12        ... ok          224 ms
  
  ======================
   All 29 tests passed.
  ======================
  ```

- **PostgreSQL 13.18**

  ```shell-session
  $ make USE_PGXS=1 tests
  bash ./scripts/test.sh
  make[1]: Entering directory '/home/postgres/.local/src/tsurugi_fdw/feature-tg_dbname'
  /usr/local/postgres/13.18/lib/pgxs/src/makefiles/../../src/test/regress/pg_regress --inputdir=./ --bindir='/usr/local/postgres/13.18/bin'    --dbname=contrib_regression test_preparation ddl_happy dml_happy data_types_happy case_sensitive_happy prep_dml_happy prep_data_types_happy prep_case_sensitive_happy manual_tutorial udf_transaction_happy udf_tg_show_tables_happy udf_tg_verify_tables_happy import_foreign_schema_happy ddl_unhappy dml_unhappy data_types_unhappy case_sensitive_unhappy prep_dml_unhappy prep_data_types_unhappy prep_case_sensitive_unhappy udf_tg_show_tables_unhappy udf_tg_show_tables_extra udf_tg_verify_tables_unhappy udf_tg_verify_tables_extra udf_transaction_unhappy import_foreign_schema_unhappy import_foreign_schema_extra dml_unhappy_pg13 prep_dml_unhappy_pg13
  (using postmaster on Unix socket, port 5431)
  pg_regress: could not set core size: disallowed by hard limit
  ============== dropping database "contrib_regression" ==============
  DROP DATABASE
  ============== creating database "contrib_regression" ==============
  CREATE DATABASE
  ALTER DATABASE
  ============== running regression test queries        ==============
  test test_preparation             ... ok           22 ms
  test ddl_happy                    ... ok         4439 ms
  test dml_happy                    ... ok         1189 ms
  test data_types_happy             ... ok         2676 ms
  test case_sensitive_happy         ... ok          169 ms
  test prep_dml_happy               ... ok         1705 ms
  test prep_data_types_happy        ... ok         2768 ms
  test prep_case_sensitive_happy    ... ok          178 ms
  test manual_tutorial              ... ok          154 ms
  test udf_transaction_happy        ... ok          626 ms
  test udf_tg_show_tables_happy     ... ok          966 ms
  test udf_tg_verify_tables_happy   ... ok         2970 ms
  test import_foreign_schema_happy  ... ok         1833 ms
  test ddl_unhappy                  ... ok         1443 ms
  test dml_unhappy                  ... ok          170 ms
  test data_types_unhappy           ... ok          796 ms
  test case_sensitive_unhappy       ... ok           67 ms
  test prep_dml_unhappy             ... ok          221 ms
  test prep_data_types_unhappy      ... ok          821 ms
  test prep_case_sensitive_unhappy  ... ok           65 ms
  test udf_tg_show_tables_unhappy   ... ok           68 ms
  test udf_tg_show_tables_extra     ... ok         4849 ms
  test udf_tg_verify_tables_unhappy ... ok           11 ms
  test udf_tg_verify_tables_extra   ... ok         9823 ms
  test udf_transaction_unhappy      ... ok          312 ms
  test import_foreign_schema_unhappy ... ok            5 ms
  test import_foreign_schema_extra  ... ok        10710 ms
  test dml_unhappy_pg13             ... ok           49 ms
  test prep_dml_unhappy_pg13        ... ok          113 ms

  ======================
   All 29 tests passed.
  ======================
  ```

- **PostgreSQL 14.18**

  ```shell-session
  $ make USE_PGXS=1 tests
  bash ./scripts/test.sh
  make[1]: Entering directory '/home/postgres/.local/src/tsurugi_fdw/feature-tg_dbname'
  /usr/local/postgres/14.18/lib/pgxs/src/makefiles/../../src/test/regress/pg_regress --inputdir=./ --bindir='/usr/local/postgres/14.18/bin'    --dbname=contrib_regression test_preparation ddl_happy dml_happy data_types_happy case_sensitive_happy prep_dml_happy prep_data_types_happy prep_case_sensitive_happy manual_tutorial udf_transaction_happy udf_tg_show_tables_happy udf_tg_verify_tables_happy import_foreign_schema_happy ddl_unhappy dml_unhappy data_types_unhappy case_sensitive_unhappy prep_dml_unhappy prep_data_types_unhappy prep_case_sensitive_unhappy udf_tg_show_tables_unhappy udf_tg_show_tables_extra udf_tg_verify_tables_unhappy udf_tg_verify_tables_extra udf_transaction_unhappy import_foreign_schema_unhappy import_foreign_schema_extra dml_unhappy_pg14-15 prep_dml_unhappy_pg14-15
  (using postmaster on Unix socket, port 5441)
  pg_regress: could not set core size: disallowed by hard limit
  ============== dropping database "contrib_regression" ==============
  DROP DATABASE
  ============== creating database "contrib_regression" ==============
  CREATE DATABASE
  ALTER DATABASE
  ============== running regression test queries        ==============
  test test_preparation             ... ok           14 ms
  test ddl_happy                    ... ok         6495 ms
  test dml_happy                    ... ok         1111 ms
  test data_types_happy             ... ok         5730 ms
  test case_sensitive_happy         ... ok          729 ms
  test prep_dml_happy               ... ok         1387 ms
  test prep_data_types_happy        ... ok         2893 ms
  test prep_case_sensitive_happy    ... ok          212 ms
  test manual_tutorial              ... ok          149 ms
  test udf_transaction_happy        ... ok          664 ms
  test udf_tg_show_tables_happy     ... ok         1155 ms
  test udf_tg_verify_tables_happy   ... ok         2903 ms
  test import_foreign_schema_happy  ... ok         1741 ms
  test ddl_unhappy                  ... ok         1629 ms
  test dml_unhappy                  ... ok          253 ms
  test data_types_unhappy           ... ok         1076 ms
  test case_sensitive_unhappy       ... ok           81 ms
  test prep_dml_unhappy             ... ok          303 ms
  test prep_data_types_unhappy      ... ok         1090 ms
  test prep_case_sensitive_unhappy  ... ok           73 ms
  test udf_tg_show_tables_unhappy   ... ok           76 ms
  test udf_tg_show_tables_extra     ... ok         3551 ms
  test udf_tg_verify_tables_unhappy ... ok            6 ms
  test udf_tg_verify_tables_extra   ... ok        13395 ms
  test udf_transaction_unhappy      ... ok          430 ms
  test import_foreign_schema_unhappy ... ok            6 ms
  test import_foreign_schema_extra  ... ok         6175 ms
  test dml_unhappy_pg14-15          ... ok           69 ms
  test prep_dml_unhappy_pg14-15     ... ok          300 ms

  ======================
  All 29 tests passed.
  ======================
  ```

- **PostgreSQL 15.13**

  ```shell-session
  $ make USE_PGXS=1 tests
  bash ./scripts/test.sh
  make[1]: Entering directory '/home/postgres/.local/src/tsurugi_fdw/feature-tg_dbname'
  echo "+++ regress install-check in  +++" && /usr/local/postgres/15.13/lib/pgxs/src/makefiles/../../src/test/regress/pg_regress --inputdir=./ --bindir='/usr/local/postgres/15.13/bin'    --dbname=contrib_regression test_preparation ddl_happy dml_happy data_types_happy case_sensitive_happy prep_dml_happy prep_data_types_happy prep_case_sensitive_happy manual_tutorial udf_transaction_happy udf_tg_show_tables_happy udf_tg_verify_tables_happy import_foreign_schema_happy ddl_unhappy dml_unhappy data_types_unhappy case_sensitive_unhappy prep_dml_unhappy prep_data_types_unhappy prep_case_sensitive_unhappy udf_tg_show_tables_unhappy udf_tg_show_tables_extra udf_tg_verify_tables_unhappy udf_tg_verify_tables_extra udf_transaction_unhappy import_foreign_schema_unhappy import_foreign_schema_extra dml_unhappy_pg14-15 prep_dml_unhappy_pg14-15
  +++ regress install-check in  +++
  (using postmaster on Unix socket, port 5451)
  pg_regress: could not set core size: disallowed by hard limit
  ============== dropping database "contrib_regression" ==============
  SET
  DROP DATABASE
  ============== creating database "contrib_regression" ==============
  CREATE DATABASE
  ALTER DATABASE
  ALTER DATABASE
  ALTER DATABASE
  ALTER DATABASE
  ALTER DATABASE
  ALTER DATABASE
  ============== running regression test queries        ==============
  test test_preparation             ... ok           32 ms
  test ddl_happy                    ... ok         4002 ms
  test dml_happy                    ... ok         1081 ms
  test data_types_happy             ... ok         2764 ms
  test case_sensitive_happy         ... ok          260 ms
  test prep_dml_happy               ... ok         1617 ms
  test prep_data_types_happy        ... ok         2998 ms
  test prep_case_sensitive_happy    ... ok          196 ms
  test manual_tutorial              ... ok          162 ms
  test udf_transaction_happy        ... ok          679 ms
  test udf_tg_show_tables_happy     ... ok         1224 ms
  test udf_tg_verify_tables_happy   ... ok         3225 ms
  test import_foreign_schema_happy  ... ok         1879 ms
  test ddl_unhappy                  ... ok          476 ms
  test dml_unhappy                  ... ok          196 ms
  test data_types_unhappy           ... ok          887 ms
  test case_sensitive_unhappy       ... ok           59 ms
  test prep_dml_unhappy             ... ok          215 ms
  test prep_data_types_unhappy      ... ok          812 ms
  test prep_case_sensitive_unhappy  ... ok           63 ms
  test udf_tg_show_tables_unhappy   ... ok           69 ms
  test udf_tg_show_tables_extra     ... ok         6767 ms
  test udf_tg_verify_tables_unhappy ... ok            7 ms
  test udf_tg_verify_tables_extra   ... ok         9755 ms
  test udf_transaction_unhappy      ... ok          279 ms
  test import_foreign_schema_unhappy ... ok            5 ms
  test import_foreign_schema_extra  ... ok         3562 ms
  test dml_unhappy_pg14-15          ... ok           40 ms
  test prep_dml_unhappy_pg14-15     ... ok           79 ms

  ======================
  All 29 tests passed.
  ======================
  ```