### PR TITLE
Fixed the test.

### DIFF
--- a/expected/dml_happy.out
+++ b/expected/dml_happy.out
@@ -1059,11 +1059,29 @@ SELECT *
 ----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----
 (0 rows)
 
------FIXME: Disabled due to issues
------SELECT *
------  FROM  fdw_join_basic_table_1 AS a
------  CROSS JOIN fdw_join_basic_table_2 AS b
------  ORDER BY b.c1, a.c1;
+SELECT *
+  FROM  fdw_join_basic_table_1 AS a
+  CROSS JOIN fdw_join_basic_table_2 AS b
+  ORDER BY b.c1, a.c1;
+ c1 | c2 | c3  | c4  |  c5  |     c6     |   c7   | c1 | c2 | c3  | c4  |  c5  |     c6     |   c7   
+----+----+-----+-----+------+------------+--------+----+----+-----+-----+------+------------+--------
+  1 | 11 | 111 | 1.1 | 1.11 | one        | first  |  1 | 11 | 111 | 1.1 | 1.11 | one        | first
+  2 | 22 | 222 | 2.2 | 2.22 | two        | second |  1 | 11 | 111 | 1.1 | 1.11 | one        | first
+  3 | 33 | 333 | 3.3 | 3.33 | three      | third  |  1 | 11 | 111 | 1.1 | 1.11 | one        | first
+  1 | 11 | 111 | 1.1 | 1.11 | one        | first  |  2 | 22 | 222 | 2.2 | 2.22 | two        | second
+  2 | 22 | 222 | 2.2 | 2.22 | two        | second |  2 | 22 | 222 | 2.2 | 2.22 | two        | second
+  3 | 33 | 333 | 3.3 | 3.33 | three      | third  |  2 | 22 | 222 | 2.2 | 2.22 | two        | second
+  1 | 11 | 111 | 1.1 | 1.11 | one        | first  |  3 | 33 | 333 | 3.3 | 3.33 | three      | third
+  2 | 22 | 222 | 2.2 | 2.22 | two        | second |  3 | 33 | 333 | 3.3 | 3.33 | three      | third
+  3 | 33 | 333 | 3.3 | 3.33 | three      | third  |  3 | 33 | 333 | 3.3 | 3.33 | three      | third
+  1 | 11 | 111 | 1.1 | 1.11 | one        | first  |  4 |    |     |     |      | NULL       | 
+  2 | 22 | 222 | 2.2 | 2.22 | two        | second |  4 |    |     |     |      | NULL       | 
+  3 | 33 | 333 | 3.3 | 3.33 | three      | third  |  4 |    |     |     |      | NULL       | 
+  1 | 11 | 111 | 1.1 | 1.11 | one        | first  |  5 | 55 | 555 | 5.5 | 5.55 | five       | fifth
+  2 | 22 | 222 | 2.2 | 2.22 | two        | second |  5 | 55 | 555 | 5.5 | 5.55 | five       | fifth
+  3 | 33 | 333 | 3.3 | 3.33 | three      | third  |  5 | 55 | 555 | 5.5 | 5.55 | five       | fifth
+(15 rows)
+
 SELECT *
   FROM fdw_join_basic_table_1 AS a
   JOIN fdw_join_basic_table_1 AS b ON a.c3 = b.c3

--- a/expected/prep_data_types_happy.out
+++ b/expected/prep_data_types_happy.out
@@ -171,14 +171,6 @@ SELECT tg_execute_ddl('
 (1 row)
 
 SELECT tg_execute_ddl('
-  CREATE TABLE fdw_type_time_tz (c TIME WITH TIME ZONE)
-', 'tsurugidb');
- tg_execute_ddl 
-----------------
- CREATE TABLE
-(1 row)
-
-SELECT tg_execute_ddl('
   CREATE TABLE fdw_type_timestamp (c TIMESTAMP)
 ', 'tsurugidb');
  tg_execute_ddl 
@@ -265,9 +257,6 @@ CREATE FOREIGN TABLE fdw_type_date (
 ) SERVER tsurugidb;
 CREATE FOREIGN TABLE fdw_type_time (
   c time
-) SERVER tsurugidb;
-CREATE FOREIGN TABLE fdw_type_time_tz (
-  c time with time zone
 ) SERVER tsurugidb;
 CREATE FOREIGN TABLE fdw_type_timestamp (
   c timestamp
@@ -1599,56 +1588,6 @@ DEALLOCATE fdw_prepare_upd_nul;
 DEALLOCATE fdw_prepare_del;
 DEALLOCATE fdw_prepare_sel_all;
 DEALLOCATE fdw_prepare_sel_all_d;
---- time with time zone
------FIXME: Disabled due to issue
------PREPARE fdw_prepare_ins (time with time zone) AS
------  INSERT INTO fdw_type_time_tz VALUES ($1);
------PREPARE fdw_prepare_upd_nul (time with time zone) AS
------  UPDATE fdw_type_time_tz SET c = $1 WHERE c IS NULL;
------PREPARE fdw_prepare_upd (time with time zone, time with time zone) AS
------  UPDATE fdw_type_time_tz SET c = $1 WHERE c = $2;
------PREPARE fdw_prepare_del (time with time zone) AS
------  DELETE FROM fdw_type_time_tz WHERE c = $1;
------PREPARE fdw_prepare_sel_all AS
------  SELECT * FROM fdw_type_time_tz ORDER BY c;
------PREPARE fdw_prepare_sel_all_d AS
------  SELECT * FROM fdw_type_time_tz ORDER BY c DESC;
------
------EXECUTE fdw_prepare_ins (time with time zone '12:34:56.789+9:00');
------EXECUTE fdw_prepare_ins ('12:34:56.789+9:00'::time with time zone);
------EXECUTE fdw_prepare_ins (CAST('12:34:56.789+9:00' AS time with time zone));
------EXECUTE fdw_prepare_ins (time with time zone '12:34:56.789+900');
------EXECUTE fdw_prepare_ins (time with time zone '12:34:56.789+9');
------EXECUTE fdw_prepare_ins (time with time zone '12:34:56.789JST');
------EXECUTE fdw_prepare_ins (time with time zone '18:01:02.3456789 -8:00');
------EXECUTE fdw_prepare_ins (time with time zone '18:01:02.3456789 -800');
------EXECUTE fdw_prepare_ins (time with time zone '18:01:02.3456789 -8');
------EXECUTE fdw_prepare_ins (time with time zone '18:01:02.3456789 PST');
------EXECUTE fdw_prepare_ins (time with time zone '00:01:02+00');
------EXECUTE fdw_prepare_ins (time with time zone '00:01:02Z');
------EXECUTE fdw_prepare_ins (time with time zone '00:01:02 z');
------EXECUTE fdw_prepare_ins (time with time zone '00:01:02 zulu');
------EXECUTE fdw_prepare_ins (time with time zone '23:59:59.999999+14');
------EXECUTE fdw_prepare_ins (NULL);
------EXECUTE fdw_prepare_ins ('04:05:06.789+9:00');
------
------SET SESSION TIMEZONE TO 'UTC';
------EXECUTE fdw_prepare_sel_all;
------
------EXECUTE fdw_prepare_upd_nul ('00:00:00.001+900'::time with time zone);
------EXECUTE fdw_prepare_sel_all;
------EXECUTE fdw_prepare_upd ('05:05:05.005005z', '18:01:02.3456789 PST');
------EXECUTE fdw_prepare_sel_all_d;
------EXECUTE fdw_prepare_del
------  (CAST('23:59:59.999999+14' AS time with time zone));
------EXECUTE fdw_prepare_sel_all;
------
------DEALLOCATE fdw_prepare_ins;
------DEALLOCATE fdw_prepare_upd;
------DEALLOCATE fdw_prepare_upd_nul;
------DEALLOCATE fdw_prepare_del;
------DEALLOCATE fdw_prepare_sel_all;
------DEALLOCATE fdw_prepare_sel_all_d;
 --- timestamp
 PREPARE fdw_prepare_ins (timestamp) AS
   INSERT INTO fdw_type_timestamp VALUES ($1);
@@ -1985,7 +1924,6 @@ DROP FOREIGN TABLE fdw_type_varchar_l;
 DROP FOREIGN TABLE fdw_type_text;
 DROP FOREIGN TABLE fdw_type_date;
 DROP FOREIGN TABLE fdw_type_time;
-DROP FOREIGN TABLE fdw_type_time_tz;
 DROP FOREIGN TABLE fdw_type_timestamp;
 DROP FOREIGN TABLE fdw_type_timestamp_wo_tz;
 DROP FOREIGN TABLE fdw_type_timestamp_tz;
@@ -2111,12 +2049,6 @@ SELECT tg_execute_ddl('DROP TABLE fdw_type_date', 'tsurugidb');
 (1 row)
 
 SELECT tg_execute_ddl('DROP TABLE fdw_type_time', 'tsurugidb');
- tg_execute_ddl 
-----------------
- DROP TABLE
-(1 row)
-
-SELECT tg_execute_ddl('DROP TABLE fdw_type_time_tz', 'tsurugidb');
  tg_execute_ddl 
 ----------------
  DROP TABLE

--- a/sql/dml_happy.sql
+++ b/sql/dml_happy.sql
@@ -392,11 +392,10 @@ SELECT *
   JOIN fdw_join_basic_table_2 AS b ON a.c4 = b.c4
   JOIN fdw_join_basic_table_1 AS c ON b.c4 = c.c4
   WHERE a.c2 = 44;
------FIXME: Disabled due to issue
------SELECT *
------  FROM  fdw_join_basic_table_1 AS a
------  CROSS JOIN fdw_join_basic_table_2 AS b
------  ORDER BY b.c1, a.c1;
+SELECT *
+  FROM  fdw_join_basic_table_1 AS a
+  CROSS JOIN fdw_join_basic_table_2 AS b
+  ORDER BY b.c1, a.c1;
 SELECT *
   FROM fdw_join_basic_table_1 AS a
   JOIN fdw_join_basic_table_1 AS b ON a.c3 = b.c3

--- a/sql/prep_data_types_happy.sql
+++ b/sql/prep_data_types_happy.sql
@@ -67,9 +67,6 @@ SELECT tg_execute_ddl('
   CREATE TABLE fdw_type_time (c TIME)
 ', 'tsurugidb');
 SELECT tg_execute_ddl('
-  CREATE TABLE fdw_type_time_tz (c TIME WITH TIME ZONE)
-', 'tsurugidb');
-SELECT tg_execute_ddl('
   CREATE TABLE fdw_type_timestamp (c TIMESTAMP)
 ', 'tsurugidb');
 SELECT tg_execute_ddl('
@@ -142,9 +139,6 @@ CREATE FOREIGN TABLE fdw_type_date (
 ) SERVER tsurugidb;
 CREATE FOREIGN TABLE fdw_type_time (
   c time
-) SERVER tsurugidb;
-CREATE FOREIGN TABLE fdw_type_time_tz (
-  c time with time zone
 ) SERVER tsurugidb;
 CREATE FOREIGN TABLE fdw_type_timestamp (
   c timestamp
@@ -873,57 +867,6 @@ DEALLOCATE fdw_prepare_del;
 DEALLOCATE fdw_prepare_sel_all;
 DEALLOCATE fdw_prepare_sel_all_d;
 
---- time with time zone
------FIXME: Disabled due to issue
------PREPARE fdw_prepare_ins (time with time zone) AS
------  INSERT INTO fdw_type_time_tz VALUES ($1);
------PREPARE fdw_prepare_upd_nul (time with time zone) AS
------  UPDATE fdw_type_time_tz SET c = $1 WHERE c IS NULL;
------PREPARE fdw_prepare_upd (time with time zone, time with time zone) AS
------  UPDATE fdw_type_time_tz SET c = $1 WHERE c = $2;
------PREPARE fdw_prepare_del (time with time zone) AS
------  DELETE FROM fdw_type_time_tz WHERE c = $1;
------PREPARE fdw_prepare_sel_all AS
------  SELECT * FROM fdw_type_time_tz ORDER BY c;
------PREPARE fdw_prepare_sel_all_d AS
------  SELECT * FROM fdw_type_time_tz ORDER BY c DESC;
------
------EXECUTE fdw_prepare_ins (time with time zone '12:34:56.789+9:00');
------EXECUTE fdw_prepare_ins ('12:34:56.789+9:00'::time with time zone);
------EXECUTE fdw_prepare_ins (CAST('12:34:56.789+9:00' AS time with time zone));
------EXECUTE fdw_prepare_ins (time with time zone '12:34:56.789+900');
------EXECUTE fdw_prepare_ins (time with time zone '12:34:56.789+9');
------EXECUTE fdw_prepare_ins (time with time zone '12:34:56.789JST');
------EXECUTE fdw_prepare_ins (time with time zone '18:01:02.3456789 -8:00');
------EXECUTE fdw_prepare_ins (time with time zone '18:01:02.3456789 -800');
------EXECUTE fdw_prepare_ins (time with time zone '18:01:02.3456789 -8');
------EXECUTE fdw_prepare_ins (time with time zone '18:01:02.3456789 PST');
------EXECUTE fdw_prepare_ins (time with time zone '00:01:02+00');
------EXECUTE fdw_prepare_ins (time with time zone '00:01:02Z');
------EXECUTE fdw_prepare_ins (time with time zone '00:01:02 z');
------EXECUTE fdw_prepare_ins (time with time zone '00:01:02 zulu');
------EXECUTE fdw_prepare_ins (time with time zone '23:59:59.999999+14');
------EXECUTE fdw_prepare_ins (NULL);
------EXECUTE fdw_prepare_ins ('04:05:06.789+9:00');
------
------SET SESSION TIMEZONE TO 'UTC';
------EXECUTE fdw_prepare_sel_all;
------
------EXECUTE fdw_prepare_upd_nul ('00:00:00.001+900'::time with time zone);
------EXECUTE fdw_prepare_sel_all;
------EXECUTE fdw_prepare_upd ('05:05:05.005005z', '18:01:02.3456789 PST');
------EXECUTE fdw_prepare_sel_all_d;
------EXECUTE fdw_prepare_del
------  (CAST('23:59:59.999999+14' AS time with time zone));
------EXECUTE fdw_prepare_sel_all;
------
------DEALLOCATE fdw_prepare_ins;
------DEALLOCATE fdw_prepare_upd;
------DEALLOCATE fdw_prepare_upd_nul;
------DEALLOCATE fdw_prepare_del;
------DEALLOCATE fdw_prepare_sel_all;
------DEALLOCATE fdw_prepare_sel_all_d;
-
 --- timestamp
 PREPARE fdw_prepare_ins (timestamp) AS
   INSERT INTO fdw_type_timestamp VALUES ($1);
@@ -1095,7 +1038,6 @@ DROP FOREIGN TABLE fdw_type_varchar_l;
 DROP FOREIGN TABLE fdw_type_text;
 DROP FOREIGN TABLE fdw_type_date;
 DROP FOREIGN TABLE fdw_type_time;
-DROP FOREIGN TABLE fdw_type_time_tz;
 DROP FOREIGN TABLE fdw_type_timestamp;
 DROP FOREIGN TABLE fdw_type_timestamp_wo_tz;
 DROP FOREIGN TABLE fdw_type_timestamp_tz;
@@ -1122,7 +1064,6 @@ SELECT tg_execute_ddl('DROP TABLE fdw_type_varchar_l', 'tsurugidb');
 SELECT tg_execute_ddl('DROP TABLE fdw_type_text', 'tsurugidb');
 SELECT tg_execute_ddl('DROP TABLE fdw_type_date', 'tsurugidb');
 SELECT tg_execute_ddl('DROP TABLE fdw_type_time', 'tsurugidb');
-SELECT tg_execute_ddl('DROP TABLE fdw_type_time_tz', 'tsurugidb');
 SELECT tg_execute_ddl('DROP TABLE fdw_type_timestamp', 'tsurugidb');
 SELECT tg_execute_ddl('DROP TABLE fdw_type_timestamp_wo_tz', 'tsurugidb');
 SELECT tg_execute_ddl('DROP TABLE fdw_type_timestamp_tz', 'tsurugidb');


### PR DESCRIPTION
Includes the following additions and changes:
- Enabled CROSS JOIN testing.
- Deleted the TIME WITH TIME ZONE test.

## Regression Testing

- **PostgreSQL 12.22**

  ```shell-session
  ============== dropping database "contrib_regression" ==============
  DROP DATABASE
  ============== creating database "contrib_regression" ==============
  CREATE DATABASE
  ALTER DATABASE
  ============== running regression test queries        ==============
  test test_preparation             ... ok           22 ms
  test ddl_happy                    ... ok        16275 ms
  test dml_happy                    ... ok         1979 ms
  test data_types_happy             ... ok         4748 ms
  test case_sensitive_happy         ... ok          293 ms
  test prep_dml_happy               ... ok         2558 ms
  test prep_data_types_happy        ... ok         4878 ms
  test prep_case_sensitive_happy    ... ok          327 ms
  test manual_tutorial              ... ok          282 ms
  test udf_transaction_happy        ... ok         1109 ms
  test udf_tg_show_tables_happy     ... ok         7800 ms
  test udf_tg_verify_tables_happy   ... ok         8584 ms
  test import_foreign_schema_happy  ... ok         4142 ms
  test ddl_unhappy                  ... ok         6676 ms
  test dml_unhappy                  ... ok          347 ms
  test data_types_unhappy           ... ok         1690 ms
  test case_sensitive_unhappy       ... ok          133 ms
  test prep_dml_unhappy             ... ok          441 ms
  test prep_data_types_unhappy      ... ok         1575 ms
  test prep_case_sensitive_unhappy  ... ok          121 ms
  test udf_tg_show_tables_unhappy   ... ok          144 ms
  test udf_tg_show_tables_extra     ... ok         5836 ms
  test udf_tg_verify_tables_unhappy ... ok           15 ms
  test udf_tg_verify_tables_extra   ... ok        26254 ms
  test udf_transaction_unhappy      ... ok         1167 ms
  test import_foreign_schema_unhappy ... ok           13 ms
  test import_foreign_schema_extra  ... ok         6220 ms
  test dml_unhappy_pg12             ... ok           60 ms
  test prep_dml_unhappy_pg12        ... ok          125 ms

  ======================
   All 29 tests passed.
  ======================
  ```

- **PostgreSQL 13.18**

  ```shell-session
  ============== dropping database "contrib_regression" ==============
  DROP DATABASE
  ============== creating database "contrib_regression" ==============
  CREATE DATABASE
  ALTER DATABASE
  ============== running regression test queries        ==============
  test test_preparation             ... ok           23 ms
  test ddl_happy                    ... ok        15986 ms
  test dml_happy                    ... ok         1937 ms
  test data_types_happy             ... ok         4591 ms
  test case_sensitive_happy         ... ok          316 ms
  test prep_dml_happy               ... ok         2788 ms
  test prep_data_types_happy        ... ok         4867 ms
  test prep_case_sensitive_happy    ... ok          346 ms
  test manual_tutorial              ... ok          461 ms
  test udf_transaction_happy        ... ok         3076 ms
  test udf_tg_show_tables_happy     ... ok         7794 ms
  test udf_tg_verify_tables_happy   ... ok        21944 ms
  test import_foreign_schema_happy  ... ok         3952 ms
  test ddl_unhappy                  ... ok         7430 ms
  test dml_unhappy                  ... ok          332 ms
  test data_types_unhappy           ... ok         1799 ms
  test case_sensitive_unhappy       ... ok          125 ms
  test prep_dml_unhappy             ... ok          439 ms
  test prep_data_types_unhappy      ... ok         1336 ms
  test prep_case_sensitive_unhappy  ... ok          116 ms
  test udf_tg_show_tables_unhappy   ... ok          129 ms
  test udf_tg_show_tables_extra     ... ok         4938 ms
  test udf_tg_verify_tables_unhappy ... ok            8 ms
  test udf_tg_verify_tables_extra   ... ok         9775 ms
  test udf_transaction_unhappy      ... ok          477 ms
  test import_foreign_schema_unhappy ... ok           14 ms
  test import_foreign_schema_extra  ... ok        19472 ms
  test dml_unhappy_pg13             ... ok          204 ms
  test prep_dml_unhappy_pg13        ... ok          503 ms

  ======================
   All 29 tests passed.
  ======================
  ```

- **PostgreSQL 14.18**

  ```shell-session
  ============== dropping database "contrib_regression" ==============
  DROP DATABASE
  ============== creating database "contrib_regression" ==============
  CREATE DATABASE
  ALTER DATABASE
  ============== running regression test queries        ==============
  test test_preparation             ... ok           26 ms
  test ddl_happy                    ... ok        26342 ms
  test dml_happy                    ... ok         1904 ms
  test data_types_happy             ... ok         4336 ms
  test case_sensitive_happy         ... ok          415 ms
  test prep_dml_happy               ... ok         2351 ms
  test prep_data_types_happy        ... ok         4619 ms
  test prep_case_sensitive_happy    ... ok          329 ms
  test manual_tutorial              ... ok          256 ms
  test udf_transaction_happy        ... ok         1086 ms
  test udf_tg_show_tables_happy     ... ok         2156 ms
  test udf_tg_verify_tables_happy   ... ok        11483 ms
  test import_foreign_schema_happy  ... ok        12375 ms
  test ddl_unhappy                  ... ok         6334 ms
  test dml_unhappy                  ... ok          263 ms
  test data_types_unhappy           ... ok         1572 ms
  test case_sensitive_unhappy       ... ok          120 ms
  test prep_dml_unhappy             ... ok          444 ms
  test prep_data_types_unhappy      ... ok         1192 ms
  test prep_case_sensitive_unhappy  ... ok           84 ms
  test udf_tg_show_tables_unhappy   ... ok           91 ms
  test udf_tg_show_tables_extra     ... ok         5083 ms
  test udf_tg_verify_tables_unhappy ... ok           54 ms
  test udf_tg_verify_tables_extra   ... ok        11075 ms
  test udf_transaction_unhappy      ... ok          458 ms
  test import_foreign_schema_unhappy ... ok           15 ms
  test import_foreign_schema_extra  ... ok         9361 ms
  test dml_unhappy_pg14-15          ... ok          198 ms
  test prep_dml_unhappy_pg14-15     ... ok          373 ms

  ======================
   All 29 tests passed.
  ======================
  ```

- **PostgreSQL 15.13**

  ```shell-session
  ============== dropping database "contrib_regression" ==============
  SET
  DROP DATABASE
  ============== creating database "contrib_regression" ==============
  CREATE DATABASE
  ALTER DATABASE
  ALTER DATABASE
  ALTER DATABASE
  ALTER DATABASE
  ALTER DATABASE
  ALTER DATABASE
  ============== running regression test queries        ==============
  test test_preparation             ... ok           43 ms
  test ddl_happy                    ... ok        12181 ms
  test dml_happy                    ... ok         2929 ms
  test data_types_happy             ... ok         4070 ms
  test case_sensitive_happy         ... ok          352 ms
  test prep_dml_happy               ... ok         2188 ms
  test prep_data_types_happy        ... ok         4250 ms
  test prep_case_sensitive_happy    ... ok          265 ms
  test manual_tutorial              ... ok          215 ms
  test udf_transaction_happy        ... ok         1115 ms
  test udf_tg_show_tables_happy     ... ok         1500 ms
  test udf_tg_verify_tables_happy   ... ok         5125 ms
  test import_foreign_schema_happy  ... ok         3827 ms
  test ddl_unhappy                  ... ok         1194 ms
  test dml_unhappy                  ... ok          309 ms
  test data_types_unhappy           ... ok         1576 ms
  test case_sensitive_unhappy       ... ok          141 ms
  test prep_dml_unhappy             ... ok          449 ms
  test prep_data_types_unhappy      ... ok         1529 ms
  test prep_case_sensitive_unhappy  ... ok          105 ms
  test udf_tg_show_tables_unhappy   ... ok          124 ms
  test udf_tg_show_tables_extra     ... ok         6271 ms
  test udf_tg_verify_tables_unhappy ... ok           12 ms
  test udf_tg_verify_tables_extra   ... ok        36483 ms
  test udf_transaction_unhappy      ... ok          724 ms
  test import_foreign_schema_unhappy ... ok           37 ms
  test import_foreign_schema_extra  ... ok        15180 ms
  test dml_unhappy_pg14-15          ... ok           72 ms
  test prep_dml_unhappy_pg14-15     ... ok          132 ms

  ======================
   All 29 tests passed.
  ======================
  ```