### PR TITLE
Fix regression tests for Tsurugi 1.9.0 error message change.

### DIFF
--- a/expected/dml_unhappy.out
+++ b/expected/dml_unhappy.out
@@ -48,7 +48,7 @@ BEGIN;
 SELECT * FROM fdw_sel_unsupported_test FOR UPDATE NOWAIT;
 ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to execute the query on Tsurugi. error: SERVER_ERROR(13)
-Tsurugi Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"appeared unexpected token: "FOR", expected one of {<END_OF_FILE>, ,, ., ;, AS, ...}" region:"region(begin=73, end=76)")
+Tsurugi Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"appeared unexpected token: "FOR", expected one of {<END_OF_FILE>, ,, ., ;, RESTART, ...}" region:"region(begin=73, end=76)")
 CONTEXT:  SQL query: SELECT id, name, value, ref_id, manager_id FROM fdw_sel_unsupported_test FOR UPDATE
 END;
 -- SELECT FOR UPDATE / SKIP LOCKED
@@ -56,7 +56,7 @@ BEGIN;
 SELECT * FROM fdw_sel_unsupported_test FOR UPDATE SKIP LOCKED;
 ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to execute the query on Tsurugi. error: SERVER_ERROR(13)
-Tsurugi Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"appeared unexpected token: "FOR", expected one of {<END_OF_FILE>, ,, ., ;, AS, ...}" region:"region(begin=73, end=76)")
+Tsurugi Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"appeared unexpected token: "FOR", expected one of {<END_OF_FILE>, ,, ., ;, RESTART, ...}" region:"region(begin=73, end=76)")
 CONTEXT:  SQL query: SELECT id, name, value, ref_id, manager_id FROM fdw_sel_unsupported_test FOR UPDATE
 END;
 -- Test teardown: DDL of the PostgreSQL

--- a/expected/prep_dml_unhappy.out
+++ b/expected/prep_dml_unhappy.out
@@ -92,7 +92,7 @@ BEGIN;
 EXECUTE fdw_prepare_sel;
 ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to execute the query on Tsurugi. error: SERVER_ERROR(13)
-Tsurugi Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"appeared unexpected token: "FOR", expected one of {<END_OF_FILE>, ,, ., ;, AS, ...}" region:"region(begin=53, end=56)")
+Tsurugi Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"appeared unexpected token: "FOR", expected one of {<END_OF_FILE>, ,, ., ;, RESTART, ...}" region:"region(begin=53, end=56)")
 CONTEXT:  SQL query: SELECT id, name, value FROM fdw_sel_unsupported_test FOR UPDATE
 END;
 DEALLOCATE fdw_prepare_sel;
@@ -103,7 +103,7 @@ BEGIN;
 EXECUTE fdw_prepare_sel;
 ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to execute the query on Tsurugi. error: SERVER_ERROR(13)
-Tsurugi Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"appeared unexpected token: "FOR", expected one of {<END_OF_FILE>, ,, ., ;, AS, ...}" region:"region(begin=53, end=56)")
+Tsurugi Error: SYNTAX_EXCEPTION (SQL-03001: compile failed with message:"appeared unexpected token: "FOR", expected one of {<END_OF_FILE>, ,, ., ;, RESTART, ...}" region:"region(begin=53, end=56)")
 CONTEXT:  SQL query: SELECT id, name, value FROM fdw_sel_unsupported_test FOR UPDATE
 END;
 DEALLOCATE fdw_prepare_sel;


### PR DESCRIPTION
Update regression test expected output to match the error message changes in Tsurugi 1.9.0.