### PR TITLE
add null check

### DIFF
--- a/src/tsurugi/tsurugi_api.cpp
+++ b/src/tsurugi/tsurugi_api.cpp
@@ -973,13 +973,15 @@ const char* tg_get_database_name() noexcept {
  */
 TGconn* tg_conn_open(
 		const char* endpoint, const char* user, const char* password) noexcept {
-	elog(DEBUG1, "tsurugi_fdw: %s (endpoint: %s, user: %s)", __func__, endpoint,
-			user);
 	if (!endpoint || endpoint[0] == '\0') {
 		endpoint = tg_get_database_name();
 	}
 	if (!user) user = "";
 	if (!password) password = "";
+	
+	elog(DEBUG1, "tsurugi_fdw: %s (endpoint: %s, user: %s)", __func__, endpoint,
+			user);
+	
 	TGconn* tg_conn = new (std::nothrow) TGconn();
 	if (!tg_conn) {
 		set_error("out of memory (new TGconn)");


### PR DESCRIPTION
- add a null check before logging output in tg_conn_open.
```
# +++ regress install-check in contrib/tsurugi_fdw +++
# using postmaster on /tmp, port 15432
ok 1         - preparation                                30 ms
ok 2         - dml_happy                                1219 ms
ok 3         - data_types_happy                         1624 ms
ok 4         - case_sensitive_happy                      191 ms
ok 5         - prep_dml_happy                           1410 ms
ok 6         - prep_data_types_happy                    1737 ms
ok 7         - prep_case_sensitive_happy                 149 ms
ok 8         - manual_tutorial                           207 ms
ok 9         - ddl_happy                                2541 ms
ok 10        - privilege_happy                           158 ms
ok 11        - udf_transaction_happy                     559 ms
ok 12        - udf_tg_show_tables_happy                  467 ms
ok 13        - udf_tg_verify_tables_happy               1046 ms
ok 14        - import_foreign_schema_happy               667 ms
ok 15        - dml_unhappy                                90 ms
ok 16        - data_types_unhappy                        491 ms
ok 17        - case_sensitive_unhappy                     48 ms
ok 18        - prep_dml_unhappy                          103 ms
ok 19        - prep_data_types_unhappy                   530 ms
ok 20        - prep_case_sensitive_unhappy                57 ms
ok 21        - udf_transaction_unhappy                   274 ms
ok 22        - ddl_unhappy                               913 ms
ok 23        - privilege_unhappy                         162 ms
ok 24        - udf_tg_show_tables_unhappy                 58 ms
ok 25        - udf_tg_show_tables_extra                  642 ms
ok 26        - udf_tg_verify_tables_unhappy               16 ms
ok 27        - udf_tg_verify_tables_extra               1424 ms
ok 28        - import_foreign_schema_unhappy              84 ms
ok 29        - import_foreign_schema_extra               945 ms
ok 30        - subselect                                1878 ms
ok 31        - update                                    307 ms
ok 32        - delete                                     77 ms
ok 33        - with                                      728 ms
ok 34        - sql_features_pg17                         467 ms
1..34
# All 34 tests passed.
```