### PR TITLE
Test/authentication 1.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,11 @@ ifdef REGRESS_EXTRA
 	endif
 endif
 
+REGRESS_AUTH ?=
+ifeq ($(REGRESS_AUTH),1)
+	REGRESS += user_mapping_happy user_mapping_unhappy
+endif
+
 install_deps:
 	bash ./scripts/install_deps.sh $(libdir)
 

--- a/expected/ddl_happy.out
+++ b/expected/ddl_happy.out
@@ -161,7 +161,7 @@ CREATE DATABASE contrib_regression_ddl;
 \c contrib_regression_ddl
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 INSERT INTO fdw_ddl_table VALUES (1), (2);
 SELECT * FROM fdw_ddl_table ORDER BY c;
@@ -193,7 +193,7 @@ CREATE DATABASE contrib_regression_ddl;
 \c contrib_regression_ddl
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 SELECT * FROM fdw_ddl_table ORDER BY c;
  c  
@@ -228,7 +228,7 @@ CREATE DATABASE contrib_regression_ddl;
 \c contrib_regression_ddl
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 UPDATE fdw_ddl_table SET c = c + 20;
 SELECT * FROM fdw_ddl_table ORDER BY c;
@@ -257,7 +257,7 @@ CREATE DATABASE contrib_regression_ddl;
 \c contrib_regression_ddl
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 DELETE FROM fdw_ddl_table WHERE c = 4;
 SELECT * FROM fdw_ddl_table ORDER BY c;
@@ -292,7 +292,7 @@ CREATE DATABASE contrib_regression_ddl;
 \c contrib_regression_ddl
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 PREPARE prep_insert(integer, integer) AS
   INSERT INTO fdw_ddl_table VALUES ($1), ($2);
@@ -329,7 +329,7 @@ CREATE DATABASE contrib_regression_ddl;
 \c contrib_regression_ddl
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 PREPARE prep_insert(integer) AS INSERT INTO fdw_ddl_table VALUES ($1);
 PREPARE prep_select AS SELECT * FROM fdw_ddl_table ORDER BY c;
@@ -368,7 +368,7 @@ CREATE DATABASE contrib_regression_ddl;
 \c contrib_regression_ddl
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 PREPARE prep_insert(integer) AS INSERT INTO fdw_ddl_table VALUES ($1);
 PREPARE prep_select AS SELECT * FROM fdw_ddl_table ORDER BY c;
@@ -401,7 +401,7 @@ CREATE DATABASE contrib_regression_ddl;
 \c contrib_regression_ddl
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 PREPARE prep_insert AS INSERT INTO fdw_ddl_table VALUES (5);
 PREPARE prep_select AS SELECT * FROM fdw_ddl_table ORDER BY c;
@@ -444,7 +444,7 @@ CREATE EXTENSION tsurugi_fdw;
 ---- Test case: Create server - COMMIT
 BEGIN;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 \des+
                                            List of foreign servers
    Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version | FDW options | Description 
@@ -465,7 +465,7 @@ BEGIN;
 DROP USER MAPPING FOR postgres SERVER tsurugidb;
 DROP SERVER tsurugidb;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw OPTIONS (endpoint 'ipc');
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 \des+
                                               List of foreign servers
    Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |   FDW options    | Description 
@@ -487,7 +487,7 @@ DROP USER MAPPING FOR postgres SERVER tsurugidb;
 DROP SERVER tsurugidb;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
   OPTIONS (endpoint 'stream', address '127.0.0.1', port '12345');
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 \des+
                                                                  List of foreign servers
    Name    |  Owner   | Foreign-data wrapper | Access privileges | Type | Version |                      FDW options                       | Description 
@@ -510,7 +510,7 @@ CREATE DATABASE contrib_regression_ddl;
 \c contrib_regression_ddl
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 ---- Test case: Alter server (incorrect server) - Connected in a transaction
 BEGIN;
@@ -550,7 +550,7 @@ CREATE DATABASE contrib_regression_ddl;
 \c contrib_regression_ddl
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 ---- Test case: Alter server (correct server) - Connected in a transaction
 SELECT * FROM fdw_ddl_table ORDER BY c;
@@ -592,7 +592,7 @@ CREATE DATABASE contrib_regression_ddl;
 \c contrib_regression_ddl
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 ---- Test case: ALTER SERVER during operations
 BEGIN;

--- a/expected/ddl_unhappy.out
+++ b/expected/ddl_unhappy.out
@@ -246,7 +246,7 @@ CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
   OPTIONS (endpoint 'stream', port '12345');
 ERROR:  missing required option "address"
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 ALTER SERVER tsurugidb OPTIONS (endpoint 'stream');
 ERROR:  missing required option "address"
 ALTER SERVER tsurugidb OPTIONS (endpoint 'stream', address '127.0.0.1');
@@ -324,7 +324,7 @@ ERROR:  "port" must be an integer value greater than zero: -1
 --- Test case: dbname option value is incorrect
 ---- Test setup: DDL of the PostgreSQL
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 ---- correct -> incorrect
 ALTER SERVER tsurugidb OPTIONS (ADD dbname 'incorrect_dbname');
@@ -333,25 +333,25 @@ ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to attach the shared memory of Tsurugi database. error: SERVER_FAILURE(10)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=incorrect_dbname, user=(null)
+DETAIL:  Connection options used: dbname=incorrect_dbname, user=tsurugi
 UPDATE fdw_ddl_table SET c = c + 10;
 ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to attach the shared memory of Tsurugi database. error: SERVER_FAILURE(10)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=incorrect_dbname, user=(null)
+DETAIL:  Connection options used: dbname=incorrect_dbname, user=tsurugi
 DELETE FROM fdw_ddl_table;
 ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to attach the shared memory of Tsurugi database. error: SERVER_FAILURE(10)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=incorrect_dbname, user=(null)
+DETAIL:  Connection options used: dbname=incorrect_dbname, user=tsurugi
 SELECT * FROM fdw_ddl_table ORDER BY c;
 ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to attach the shared memory of Tsurugi database. error: SERVER_FAILURE(10)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=incorrect_dbname, user=(null)
+DETAIL:  Connection options used: dbname=incorrect_dbname, user=tsurugi
 ---- incorrect -> correct
 ALTER SERVER tsurugidb OPTIONS (DROP dbname);
 INSERT INTO fdw_ddl_table VALUES (2);
@@ -386,25 +386,25 @@ ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to attach the shared memory of Tsurugi database. error: SERVER_FAILURE(10)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=incorrect_dbname, user=(null)
+DETAIL:  Connection options used: dbname=incorrect_dbname, user=tsurugi
 EXECUTE prep_update(10);
 ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to attach the shared memory of Tsurugi database. error: SERVER_FAILURE(10)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=incorrect_dbname, user=(null)
+DETAIL:  Connection options used: dbname=incorrect_dbname, user=tsurugi
 EXECUTE prep_delete;
 ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to attach the shared memory of Tsurugi database. error: SERVER_FAILURE(10)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=incorrect_dbname, user=(null)
+DETAIL:  Connection options used: dbname=incorrect_dbname, user=tsurugi
 EXECUTE prep_select;
 ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to attach the shared memory of Tsurugi database. error: SERVER_FAILURE(10)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=incorrect_dbname, user=(null)
+DETAIL:  Connection options used: dbname=incorrect_dbname, user=tsurugi
 ---- incorrect -> correct (preparation)
 ALTER SERVER tsurugidb OPTIONS (SET dbname 'tsurugi');
 -- EXECUTE prep_insert(2);
@@ -430,7 +430,7 @@ CREATE DATABASE contrib_regression_ddl;
 \c contrib_regression_ddl
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 ---- Test case: Alter server (incorrect server) - Connected outside a transaction
 SELECT * FROM fdw_ddl_table ORDER BY c;
@@ -452,7 +452,7 @@ ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to attach the shared memory of Tsurugi database. error: SERVER_FAILURE(10)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=incorrect, user=(null)
+DETAIL:  Connection options used: dbname=incorrect, user=tsurugi
 END;
 \des+
                                            List of foreign servers
@@ -486,7 +486,7 @@ ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to attach the shared memory of Tsurugi database. error: SERVER_FAILURE(10)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=incorrect, user=(null)
+DETAIL:  Connection options used: dbname=incorrect, user=tsurugi
 END;
 BEGIN;
 ALTER SERVER tsurugidb OPTIONS (SET dbname 'tsurugi');
@@ -500,7 +500,7 @@ CREATE DATABASE contrib_regression_ddl;
 \c contrib_regression_ddl
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 ---- Test case: ALTER SERVER during operations
 BEGIN;
@@ -552,7 +552,7 @@ ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to attach the shared memory of Tsurugi database. error: SERVER_FAILURE(10)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=incorrect-4, user=(null)
+DETAIL:  Connection options used: dbname=incorrect-4, user=tsurugi
 END;
 ALTER SERVER tsurugidb OPTIONS (DROP dbname);
 \des+
@@ -578,7 +578,7 @@ CREATE DATABASE contrib_regression_ddl;
 \c contrib_regression_ddl
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 --- Test case: ALTER SERVER during operations
 INSERT INTO fdw_ddl_table VALUES (1), (2);
@@ -588,7 +588,7 @@ ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to attach the shared memory of Tsurugi database. error: SERVER_FAILURE(10)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=incorrect, user=(null)
+DETAIL:  Connection options used: dbname=incorrect, user=tsurugi
 ALTER SERVER tsurugidb OPTIONS (SET dbname 'tsurugi');
 -- UPDATE fdw_ddl_table SET c=c+10;
 ALTER SERVER tsurugidb OPTIONS (DROP dbname);
@@ -605,7 +605,7 @@ ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to attach the shared memory of Tsurugi database. error: SERVER_FAILURE(10)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=incorrect, user=(null)
+DETAIL:  Connection options used: dbname=incorrect, user=tsurugi
 ALTER SERVER tsurugidb OPTIONS (SET dbname 'tsurugi');
 -- DELETE FROM fdw_ddl_table;
 -- SELECT * FROM fdw_ddl_table ORDER BY c;

--- a/expected/manual_tutorial.out
+++ b/expected/manual_tutorial.out
@@ -64,7 +64,7 @@ SELECT * FROM weather ORDER BY id;
 
 /* データベースロールの作成 */
 CREATE ROLE jonathan;
-CREATE USER MAPPING FOR Jonathan SERVER tsurugidb;
+CREATE USER MAPPING FOR Jonathan SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 /* アクセス権の付与 */
 GRANT SELECT ON weather TO jonathan;    -- Tsurugiテーブルにアクセス権を付与します
 /* Tsurugiテーブルのアクセス制御 */

--- a/expected/preparation.out
+++ b/expected/preparation.out
@@ -1,6 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS tsurugi_fdw;
 CREATE SERVER IF NOT EXISTS tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING IF NOT EXISTS FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING IF NOT EXISTS FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 \dx tsurugi_fdw
                    List of installed extensions
     Name     | Version | Schema |           Description            

--- a/expected/privilege_happy.out
+++ b/expected/privilege_happy.out
@@ -11,7 +11,7 @@ SELECT tg_execute_ddl('
 /* Test setup: DDL of the PostgreSQL */
 CREATE FOREIGN TABLE fdw_privilege_test (col integer) SERVER tsurugidb;
 CREATE ROLE tgfdw_regress_user;
-CREATE USER MAPPING FOR tgfdw_regress_user SERVER tsurugidb;
+CREATE USER MAPPING FOR tgfdw_regress_user SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 -- All privileges
 GRANT ALL ON fdw_privilege_test TO tgfdw_regress_user;
 SET ROLE tgfdw_regress_user;

--- a/expected/privilege_unhappy.out
+++ b/expected/privilege_unhappy.out
@@ -11,7 +11,7 @@ SELECT tg_execute_ddl('
 /* Test setup: DDL of the PostgreSQL */
 CREATE FOREIGN TABLE fdw_privilege_test (col integer) SERVER tsurugidb;
 CREATE ROLE tgfdw_regress_user;
-CREATE USER MAPPING FOR tgfdw_regress_user SERVER tsurugidb;
+CREATE USER MAPPING FOR tgfdw_regress_user SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 -- No privileges
 SET ROLE tgfdw_regress_user;
 INSERT INTO fdw_privilege_test VALUES (1);            -- failed

--- a/expected/udf_tg_show_tables_happy.out
+++ b/expected/udf_tg_show_tables_happy.out
@@ -412,7 +412,7 @@ SELECT tg_execute_ddl('
 
 --- Test setup: DDL of the PostgreSQL
 CREATE SERVER other_server FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER other_server;
+CREATE USER MAPPING FOR postgres SERVER other_server OPTIONS (user 'tsurugi', password 'password');
 --- Test
 SELECT tg_show_tables('tg_schema', 'other_server', 'detail', true);
              tg_show_tables             
@@ -461,7 +461,7 @@ SELECT tg_execute_ddl('
 
 --- Test setup: DDL of the PostgreSQL
 CREATE SERVER "Tsurugidb" FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER "Tsurugidb";
+CREATE USER MAPPING FOR postgres SERVER "Tsurugidb" OPTIONS (user 'tsurugi', password 'password');
 --- Test
 SELECT tg_show_tables('tg_schema', 'tsurugidb', 'detail', true);
             tg_show_tables             

--- a/expected/udf_tg_verify_tables_happy.out
+++ b/expected/udf_tg_verify_tables_happy.out
@@ -2102,7 +2102,7 @@ SELECT tg_execute_ddl('
 
 --- Test setup: DDL of the PostgreSQL
 CREATE SERVER other_server FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER other_server;
+CREATE USER MAPPING FOR postgres SERVER other_server OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE udf_test_table_1 (
   id integer,
   name text
@@ -2237,7 +2237,7 @@ SELECT tg_execute_ddl('
 
 --- Test setup: DDL of the PostgreSQL
 CREATE SERVER "Tsurugidb" FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER "Tsurugidb";
+CREATE USER MAPPING FOR postgres SERVER "Tsurugidb" OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE udf_test_table_1 (
   id integer,
   name text

--- a/expected/user_mapping_happy.out
+++ b/expected/user_mapping_happy.out
@@ -1,8 +1,9 @@
 -- Setup
 SET ROLE postgres;
-CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE ROLE um_test_a LOGIN;
+GRANT CREATE ON SCHEMA public TO um_test_a;
 CREATE ROLE um_test_b LOGIN;
+GRANT CREATE ON SCHEMA public TO um_test_b;
 GRANT USAGE ON FOREIGN SERVER tsurugidb TO um_test_a, um_test_b;
 -- Create mapping for explicit role
 SET ROLE um_test_a;
@@ -273,5 +274,7 @@ DROP USER MAPPING IF EXISTS FOR um_test_a SERVER tsurugidb;
 DROP USER MAPPING IF EXISTS FOR um_test_b SERVER tsurugidb;
 REVOKE USAGE ON FOREIGN SERVER tsurugidb FROM um_test_a, um_test_b;
 DROP USER MAPPING FOR CURRENT_USER SERVER tsurugidb;
+REVOKE CREATE ON SCHEMA public FROM um_test_a;
 DROP ROLE IF EXISTS um_test_a;
+REVOKE CREATE ON SCHEMA public FROM um_test_b;
 DROP ROLE IF EXISTS um_test_b;

--- a/expected/user_mapping_unhappy.out
+++ b/expected/user_mapping_unhappy.out
@@ -92,7 +92,7 @@ ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to connect to Tsurugi database. error: AUTHENTICATION_ERROR(14)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=tsurugi1, user=bad_ua
+DETAIL:  Connection options used: dbname=(null), user=bad_ua
 -- Invalid password authentication fails (ERROR)
 DROP USER MAPPING IF EXISTS FOR um_test_a SERVER tsurugidb;
 CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (user 'ua', password 'bad_pa');
@@ -101,7 +101,7 @@ ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to connect to Tsurugi database. error: AUTHENTICATION_ERROR(14)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=tsurugi1, user=ua
+DETAIL:  Connection options used: dbname=(null), user=ua
 -- Invalid username and password authentication fails (ERROR)
 DROP USER MAPPING IF EXISTS FOR um_test_a SERVER tsurugidb;
 CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (user 'bad_ua', password 'bad_pa');
@@ -110,7 +110,7 @@ ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to connect to Tsurugi database. error: AUTHENTICATION_ERROR(14)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=tsurugi1, user=bad_ua
+DETAIL:  Connection options used: dbname=(null), user=bad_ua
 -- Missing username authentication fails (ERROR)
 DROP USER MAPPING IF EXISTS FOR um_test_a SERVER tsurugidb;
 CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (password 'pa');
@@ -119,7 +119,7 @@ ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to connect to Tsurugi database. error: AUTHENTICATION_ERROR(14)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=tsurugi1, user=(null)
+DETAIL:  Connection options used: dbname=(null), user=(null)
 -- Missing password authentication fails (ERROR)
 DROP USER MAPPING IF EXISTS FOR um_test_a SERVER tsurugidb;
 CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (user 'ua');
@@ -128,7 +128,7 @@ ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to connect to Tsurugi database. error: AUTHENTICATION_ERROR(14)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=tsurugi1, user=ua
+DETAIL:  Connection options used: dbname=(null), user=ua
 -- Missing credentials authentication fails (ERROR)
 DROP USER MAPPING IF EXISTS FOR um_test_a SERVER tsurugidb;
 CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb;
@@ -137,7 +137,7 @@ ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to connect to Tsurugi database. error: AUTHENTICATION_ERROR(14)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=tsurugi1, user=(null)
+DETAIL:  Connection options used: dbname=(null), user=(null)
 -- Same session connection reuse second SELECT runs without reauthentication
 DROP USER MAPPING IF EXISTS FOR um_test_a SERVER tsurugidb;
 CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (user 'ua', password 'pa');
@@ -155,7 +155,7 @@ ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to connect to Tsurugi database. error: AUTHENTICATION_ERROR(14)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=tsurugi1, user=bad_ua
+DETAIL:  Connection options used: dbname=(null), user=bad_ua
 -- Role switch requires authentication
 SET ROLE um_test_b;
 CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (user 'bad_ub', password 'bad_pb');
@@ -176,7 +176,7 @@ ERROR:  tsurugi_fdw: Failed to execute remote SQL.
 HINT:  Failed to connect to Tsurugi database. error: AUTHENTICATION_ERROR(14)
 No detail message.
 CONTEXT:  SQL query: 
-DETAIL:  Connection options used: dbname=tsurugi1, user=bad_ub
+DETAIL:  Connection options used: dbname=(null), user=bad_ub
 -- Cleanup
 SET ROLE postgres;
 DROP FOREIGN TABLE fdw_um_auth_table_1;

--- a/expected/user_mapping_unhappy.out
+++ b/expected/user_mapping_unhappy.out
@@ -2,7 +2,9 @@
 SET ROLE postgres;
 CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE ROLE um_test_a LOGIN;
+GRANT CREATE ON SCHEMA public TO um_test_a;
 CREATE ROLE um_test_b LOGIN;
+GRANT CREATE ON SCHEMA public TO um_test_b;
 GRANT USAGE ON FOREIGN SERVER tsurugidb TO um_test_a, um_test_b;
 SET ROLE um_test_a;
 -- Invalid option name "username"
@@ -86,32 +88,56 @@ GRANT ALL ON TABLE fdw_um_auth_table_1 TO um_test_b;
 DROP USER MAPPING IF EXISTS FOR um_test_a SERVER tsurugidb;
 CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (user 'bad_ua', password 'pa');
 SELECT * FROM fdw_um_auth_table_1;
-ERROR:  Invalid username or password for Tsurugi connection. error: AUTHENTICATION_ERROR(14)
+ERROR:  tsurugi_fdw: Failed to execute remote SQL.
+HINT:  Failed to connect to Tsurugi database. error: AUTHENTICATION_ERROR(14)
+No detail message.
+CONTEXT:  SQL query: 
+DETAIL:  Connection options used: dbname=tsurugi1, user=bad_ua
 -- Invalid password authentication fails (ERROR)
 DROP USER MAPPING IF EXISTS FOR um_test_a SERVER tsurugidb;
 CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (user 'ua', password 'bad_pa');
 SELECT * FROM fdw_um_auth_table_1;
-ERROR:  Invalid username or password for Tsurugi connection. error: AUTHENTICATION_ERROR(14)
+ERROR:  tsurugi_fdw: Failed to execute remote SQL.
+HINT:  Failed to connect to Tsurugi database. error: AUTHENTICATION_ERROR(14)
+No detail message.
+CONTEXT:  SQL query: 
+DETAIL:  Connection options used: dbname=tsurugi1, user=ua
 -- Invalid username and password authentication fails (ERROR)
 DROP USER MAPPING IF EXISTS FOR um_test_a SERVER tsurugidb;
 CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (user 'bad_ua', password 'bad_pa');
 SELECT * FROM fdw_um_auth_table_1;
-ERROR:  Invalid username or password for Tsurugi connection. error: AUTHENTICATION_ERROR(14)
+ERROR:  tsurugi_fdw: Failed to execute remote SQL.
+HINT:  Failed to connect to Tsurugi database. error: AUTHENTICATION_ERROR(14)
+No detail message.
+CONTEXT:  SQL query: 
+DETAIL:  Connection options used: dbname=tsurugi1, user=bad_ua
 -- Missing username authentication fails (ERROR)
 DROP USER MAPPING IF EXISTS FOR um_test_a SERVER tsurugidb;
 CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (password 'pa');
 SELECT * FROM fdw_um_auth_table_1;
-ERROR:  Invalid username or password for Tsurugi connection. error: AUTHENTICATION_ERROR(14)
+ERROR:  tsurugi_fdw: Failed to execute remote SQL.
+HINT:  Failed to connect to Tsurugi database. error: AUTHENTICATION_ERROR(14)
+No detail message.
+CONTEXT:  SQL query: 
+DETAIL:  Connection options used: dbname=tsurugi1, user=(null)
 -- Missing password authentication fails (ERROR)
 DROP USER MAPPING IF EXISTS FOR um_test_a SERVER tsurugidb;
 CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (user 'ua');
 SELECT * FROM fdw_um_auth_table_1;
-ERROR:  Invalid username or password for Tsurugi connection. error: AUTHENTICATION_ERROR(14)
+ERROR:  tsurugi_fdw: Failed to execute remote SQL.
+HINT:  Failed to connect to Tsurugi database. error: AUTHENTICATION_ERROR(14)
+No detail message.
+CONTEXT:  SQL query: 
+DETAIL:  Connection options used: dbname=tsurugi1, user=ua
 -- Missing credentials authentication fails (ERROR)
 DROP USER MAPPING IF EXISTS FOR um_test_a SERVER tsurugidb;
 CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb;
 SELECT * FROM fdw_um_auth_table_1;
-ERROR:  Invalid username or password for Tsurugi connection. error: AUTHENTICATION_ERROR(14)
+ERROR:  tsurugi_fdw: Failed to execute remote SQL.
+HINT:  Failed to connect to Tsurugi database. error: AUTHENTICATION_ERROR(14)
+No detail message.
+CONTEXT:  SQL query: 
+DETAIL:  Connection options used: dbname=tsurugi1, user=(null)
 -- Same session connection reuse second SELECT runs without reauthentication
 DROP USER MAPPING IF EXISTS FOR um_test_a SERVER tsurugidb;
 CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (user 'ua', password 'pa');
@@ -125,7 +151,11 @@ SELECT * FROM fdw_um_auth_table_1;
 
 ALTER USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (SET user 'bad_ua', SET password 'bad_pa');
 SELECT * FROM fdw_um_auth_table_1;
-ERROR:  Invalid username or password for Tsurugi connection. error: AUTHENTICATION_ERROR(14)
+ERROR:  tsurugi_fdw: Failed to execute remote SQL.
+HINT:  Failed to connect to Tsurugi database. error: AUTHENTICATION_ERROR(14)
+No detail message.
+CONTEXT:  SQL query: 
+DETAIL:  Connection options used: dbname=tsurugi1, user=bad_ua
 -- Role switch requires authentication
 SET ROLE um_test_b;
 CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (user 'bad_ub', password 'bad_pb');
@@ -142,7 +172,11 @@ SELECT * FROM fdw_um_auth_table_1;
 
 SET ROLE um_test_b;
 SELECT * FROM fdw_um_auth_table_1;
-ERROR:  Invalid username or password for Tsurugi connection. error: AUTHENTICATION_ERROR(14)
+ERROR:  tsurugi_fdw: Failed to execute remote SQL.
+HINT:  Failed to connect to Tsurugi database. error: AUTHENTICATION_ERROR(14)
+No detail message.
+CONTEXT:  SQL query: 
+DETAIL:  Connection options used: dbname=tsurugi1, user=bad_ub
 -- Cleanup
 SET ROLE postgres;
 DROP FOREIGN TABLE fdw_um_auth_table_1;
@@ -155,5 +189,7 @@ SELECT tg_execute_ddl('DROP TABLE fdw_um_auth_table_1', 'tsurugidb');
 DROP USER MAPPING IF EXISTS FOR um_test_a SERVER tsurugidb;
 REVOKE USAGE ON FOREIGN SERVER tsurugidb FROM um_test_a, um_test_b;
 DROP USER MAPPING IF EXISTS FOR um_test_b SERVER tsurugidb;
+REVOKE CREATE ON SCHEMA public FROM um_test_a;
 DROP ROLE IF EXISTS um_test_a;
+REVOKE CREATE ON SCHEMA public FROM um_test_b;
 DROP ROLE IF EXISTS um_test_b;

--- a/sql/ddl_happy.sql
+++ b/sql/ddl_happy.sql
@@ -87,7 +87,7 @@ CREATE DATABASE contrib_regression_ddl;
 CREATE EXTENSION tsurugi_fdw;
 
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 
 INSERT INTO fdw_ddl_table VALUES (1), (2);
@@ -106,7 +106,7 @@ CREATE DATABASE contrib_regression_ddl;
 CREATE EXTENSION tsurugi_fdw;
 
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 
 SELECT * FROM fdw_ddl_table ORDER BY c;
@@ -126,7 +126,7 @@ CREATE DATABASE contrib_regression_ddl;
 CREATE EXTENSION tsurugi_fdw;
 
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 
 UPDATE fdw_ddl_table SET c = c + 20;
@@ -145,7 +145,7 @@ CREATE DATABASE contrib_regression_ddl;
 CREATE EXTENSION tsurugi_fdw;
 
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 
 DELETE FROM fdw_ddl_table WHERE c = 4;
@@ -166,7 +166,7 @@ CREATE DATABASE contrib_regression_ddl;
 CREATE EXTENSION tsurugi_fdw;
 
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 
 PREPARE prep_insert(integer, integer) AS
@@ -191,7 +191,7 @@ CREATE DATABASE contrib_regression_ddl;
 CREATE EXTENSION tsurugi_fdw;
 
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 
 PREPARE prep_insert(integer) AS INSERT INTO fdw_ddl_table VALUES ($1);
@@ -216,7 +216,7 @@ CREATE DATABASE contrib_regression_ddl;
 CREATE EXTENSION tsurugi_fdw;
 
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 
 PREPARE prep_insert(integer) AS INSERT INTO fdw_ddl_table VALUES ($1);
@@ -240,7 +240,7 @@ CREATE DATABASE contrib_regression_ddl;
 CREATE EXTENSION tsurugi_fdw;
 
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 
 PREPARE prep_insert AS INSERT INTO fdw_ddl_table VALUES (5);
@@ -270,7 +270,7 @@ CREATE EXTENSION tsurugi_fdw;
 ---- Test case: Create server - COMMIT
 BEGIN;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 \des+
 COMMIT;
 \des+
@@ -280,7 +280,7 @@ BEGIN;
 DROP USER MAPPING FOR postgres SERVER tsurugidb;
 DROP SERVER tsurugidb;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw OPTIONS (endpoint 'ipc');
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 \des+
 COMMIT;
 \des+
@@ -291,7 +291,7 @@ DROP USER MAPPING FOR postgres SERVER tsurugidb;
 DROP SERVER tsurugidb;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
   OPTIONS (endpoint 'stream', address '127.0.0.1', port '12345');
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 \des+
 ROLLBACK;
 \des+
@@ -305,7 +305,7 @@ CREATE DATABASE contrib_regression_ddl;
 
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 
 ---- Test case: Alter server (incorrect server) - Connected in a transaction
@@ -327,7 +327,7 @@ CREATE DATABASE contrib_regression_ddl;
 
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 
 ---- Test case: Alter server (correct server) - Connected in a transaction
@@ -351,7 +351,7 @@ CREATE DATABASE contrib_regression_ddl;
 
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 
 ---- Test case: ALTER SERVER during operations

--- a/sql/ddl_unhappy.sql
+++ b/sql/ddl_unhappy.sql
@@ -119,7 +119,7 @@ CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
   OPTIONS (endpoint 'stream', port '12345');
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 ALTER SERVER tsurugidb OPTIONS (endpoint 'stream');
 ALTER SERVER tsurugidb OPTIONS (endpoint 'stream', address '127.0.0.1');
 ALTER SERVER tsurugidb OPTIONS (endpoint 'stream', port '12345');
@@ -176,7 +176,7 @@ CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw
 --- Test case: dbname option value is incorrect
 ---- Test setup: DDL of the PostgreSQL
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 
 ---- correct -> incorrect
@@ -238,7 +238,7 @@ CREATE DATABASE contrib_regression_ddl;
 
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 
 ---- Test case: Alter server (incorrect server) - Connected outside a transaction
@@ -274,7 +274,7 @@ CREATE DATABASE contrib_regression_ddl;
 
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 
 ---- Test case: ALTER SERVER during operations
@@ -314,7 +314,7 @@ CREATE DATABASE contrib_regression_ddl;
 
 CREATE EXTENSION tsurugi_fdw;
 CREATE SERVER tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE fdw_ddl_table (c integer) SERVER tsurugidb;
 
 --- Test case: ALTER SERVER during operations

--- a/sql/manual_tutorial.sql
+++ b/sql/manual_tutorial.sql
@@ -46,7 +46,7 @@ SELECT * FROM weather ORDER BY id;
 
 /* データベースロールの作成 */
 CREATE ROLE jonathan;
-CREATE USER MAPPING FOR Jonathan SERVER tsurugidb;
+CREATE USER MAPPING FOR Jonathan SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 
 /* アクセス権の付与 */
 GRANT SELECT ON weather TO jonathan;    -- Tsurugiテーブルにアクセス権を付与します

--- a/sql/preparation.sql
+++ b/sql/preparation.sql
@@ -1,6 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS tsurugi_fdw;
 CREATE SERVER IF NOT EXISTS tsurugidb FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING IF NOT EXISTS FOR postgres SERVER tsurugidb;
+CREATE USER MAPPING IF NOT EXISTS FOR postgres SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 
 \dx tsurugi_fdw
 \deu postgres

--- a/sql/privilege_happy.sql
+++ b/sql/privilege_happy.sql
@@ -8,7 +8,7 @@ SELECT tg_execute_ddl('
 /* Test setup: DDL of the PostgreSQL */
 CREATE FOREIGN TABLE fdw_privilege_test (col integer) SERVER tsurugidb;
 CREATE ROLE tgfdw_regress_user;
-CREATE USER MAPPING FOR tgfdw_regress_user SERVER tsurugidb;
+CREATE USER MAPPING FOR tgfdw_regress_user SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 
 -- All privileges
 GRANT ALL ON fdw_privilege_test TO tgfdw_regress_user;

--- a/sql/privilege_unhappy.sql
+++ b/sql/privilege_unhappy.sql
@@ -8,7 +8,7 @@ SELECT tg_execute_ddl('
 /* Test setup: DDL of the PostgreSQL */
 CREATE FOREIGN TABLE fdw_privilege_test (col integer) SERVER tsurugidb;
 CREATE ROLE tgfdw_regress_user;
-CREATE USER MAPPING FOR tgfdw_regress_user SERVER tsurugidb;
+CREATE USER MAPPING FOR tgfdw_regress_user SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 
 -- No privileges
 SET ROLE tgfdw_regress_user;

--- a/sql/udf_tg_show_tables_happy.sql
+++ b/sql/udf_tg_show_tables_happy.sql
@@ -135,7 +135,7 @@ SELECT tg_execute_ddl('
 ', 'tsurugidb');
 --- Test setup: DDL of the PostgreSQL
 CREATE SERVER other_server FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER other_server;
+CREATE USER MAPPING FOR postgres SERVER other_server OPTIONS (user 'tsurugi', password 'password');
 --- Test
 SELECT tg_show_tables('tg_schema', 'other_server', 'detail', true);
 --- Test teardown: DDL of the PostgreSQL
@@ -152,7 +152,7 @@ SELECT tg_execute_ddl('
 ', 'tsurugidb');
 --- Test setup: DDL of the PostgreSQL
 CREATE SERVER "Tsurugidb" FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER "Tsurugidb";
+CREATE USER MAPPING FOR postgres SERVER "Tsurugidb" OPTIONS (user 'tsurugi', password 'password');
 --- Test
 SELECT tg_show_tables('tg_schema', 'tsurugidb', 'detail', true);
 SELECT tg_show_tables('tg_schema', 'Tsurugidb', 'detail', true);

--- a/sql/udf_tg_verify_tables_happy.sql
+++ b/sql/udf_tg_verify_tables_happy.sql
@@ -825,7 +825,7 @@ SELECT tg_execute_ddl('
 ', 'tsurugidb');
 --- Test setup: DDL of the PostgreSQL
 CREATE SERVER other_server FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER other_server;
+CREATE USER MAPPING FOR postgres SERVER other_server OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE udf_test_table_1 (
   id integer,
   name text
@@ -865,7 +865,7 @@ SELECT tg_execute_ddl('
 ', 'tsurugidb');
 --- Test setup: DDL of the PostgreSQL
 CREATE SERVER "Tsurugidb" FOREIGN DATA WRAPPER tsurugi_fdw;
-CREATE USER MAPPING FOR postgres SERVER "Tsurugidb";
+CREATE USER MAPPING FOR postgres SERVER "Tsurugidb" OPTIONS (user 'tsurugi', password 'password');
 CREATE FOREIGN TABLE udf_test_table_1 (
   id integer,
   name text

--- a/sql/user_mapping_happy.sql
+++ b/sql/user_mapping_happy.sql
@@ -1,8 +1,9 @@
 -- Setup
 SET ROLE postgres;
-CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE ROLE um_test_a LOGIN;
+GRANT CREATE ON SCHEMA public TO um_test_a;
 CREATE ROLE um_test_b LOGIN;
+GRANT CREATE ON SCHEMA public TO um_test_b;
 GRANT USAGE ON FOREIGN SERVER tsurugidb TO um_test_a, um_test_b;
 
 -- Create mapping for explicit role
@@ -141,5 +142,7 @@ DROP USER MAPPING IF EXISTS FOR um_test_a SERVER tsurugidb;
 DROP USER MAPPING IF EXISTS FOR um_test_b SERVER tsurugidb;
 REVOKE USAGE ON FOREIGN SERVER tsurugidb FROM um_test_a, um_test_b;
 DROP USER MAPPING FOR CURRENT_USER SERVER tsurugidb;
+REVOKE CREATE ON SCHEMA public FROM um_test_a;
 DROP ROLE IF EXISTS um_test_a;
+REVOKE CREATE ON SCHEMA public FROM um_test_b;
 DROP ROLE IF EXISTS um_test_b;

--- a/sql/user_mapping_unhappy.sql
+++ b/sql/user_mapping_unhappy.sql
@@ -2,7 +2,9 @@
 SET ROLE postgres;
 CREATE USER MAPPING FOR CURRENT_USER SERVER tsurugidb OPTIONS (user 'tsurugi', password 'password');
 CREATE ROLE um_test_a LOGIN;
+GRANT CREATE ON SCHEMA public TO um_test_a;
 CREATE ROLE um_test_b LOGIN;
+GRANT CREATE ON SCHEMA public TO um_test_b;
 GRANT USAGE ON FOREIGN SERVER tsurugidb TO um_test_a, um_test_b;
 SET ROLE um_test_a;
 
@@ -116,5 +118,7 @@ SELECT tg_execute_ddl('DROP TABLE fdw_um_auth_table_1', 'tsurugidb');
 DROP USER MAPPING IF EXISTS FOR um_test_a SERVER tsurugidb;
 REVOKE USAGE ON FOREIGN SERVER tsurugidb FROM um_test_a, um_test_b;
 DROP USER MAPPING IF EXISTS FOR um_test_b SERVER tsurugidb;
+REVOKE CREATE ON SCHEMA public FROM um_test_a;
 DROP ROLE IF EXISTS um_test_a;
+REVOKE CREATE ON SCHEMA public FROM um_test_b;
 DROP ROLE IF EXISTS um_test_b;

--- a/src/fdw/connection.c
+++ b/src/fdw/connection.c
@@ -67,6 +67,7 @@
 typedef struct ConnCacheKey
 {
 	Oid serverid; /* ForeignServer Oid */
+	Oid userid;
 } ConnCacheKey;
 
 typedef struct ConnCacheEntry
@@ -214,6 +215,7 @@ get_connection_entry(Oid serverid)
 	bool			found;
 
 	key.serverid = serverid;
+	key.userid   = GetUserId();
 
 	entry = (ConnCacheEntry *) hash_search(ConnectionHash, &key, HASH_ENTER, &found);
 

--- a/src/tsurugi/tsurugi_api.cpp
+++ b/src/tsurugi/tsurugi_api.cpp
@@ -65,18 +65,15 @@ typedef struct {
 
 struct TGconn {
 	static StubPtr stub;
-	//static ConnectionPtr impl;
 	ConnectionPtr impl;
 	TransactionPtr tx;
 	std::string endpoint;
 	Oid server_id;
 	bool subxact_seen = false;
 	ErrorState error;
-	//TGconn() : tx(nullptr), server_id(InvalidOid) {}
 	TGconn() : impl(nullptr), tx(nullptr), server_id(InvalidOid) {}
 };
 StubPtr TGconn::stub = nullptr;
-//ConnectionPtr TGconn::impl = nullptr;
 
 struct TGstmt {
 	TGconn* conn;

--- a/src/tsurugi/tsurugi_api.cpp
+++ b/src/tsurugi/tsurugi_api.cpp
@@ -65,16 +65,18 @@ typedef struct {
 
 struct TGconn {
 	static StubPtr stub;
-	static ConnectionPtr impl;
+	//static ConnectionPtr impl;
+	ConnectionPtr impl;
 	TransactionPtr tx;
 	std::string endpoint;
 	Oid server_id;
 	bool subxact_seen = false;
 	ErrorState error;
-	TGconn() : tx(nullptr), server_id(InvalidOid) {}
+	//TGconn() : tx(nullptr), server_id(InvalidOid) {}
+	TGconn() : impl(nullptr), tx(nullptr), server_id(InvalidOid) {}
 };
 StubPtr TGconn::stub = nullptr;
-ConnectionPtr TGconn::impl = nullptr;
+//ConnectionPtr TGconn::impl = nullptr;
 
 struct TGstmt {
 	TGconn* conn;


### PR DESCRIPTION
- Add auth test
- Fix for user mapping of connection processing

```
# +++ regress install-check in contrib/tsurugi_fdw +++
# using postmaster on /tmp, port 15432
ok 1         - preparation                                31 ms
ok 2         - dml_happy                                1316 ms
ok 3         - data_types_happy                         1738 ms
ok 4         - case_sensitive_happy                      222 ms
ok 5         - prep_dml_happy                           1238 ms
ok 6         - prep_data_types_happy                    1807 ms
ok 7         - prep_case_sensitive_happy                 144 ms
ok 8         - manual_tutorial                           254 ms
ok 9         - ddl_happy                                2833 ms
ok 10        - privilege_happy                           201 ms
ok 11        - udf_transaction_happy                     601 ms
ok 12        - udf_tg_show_tables_happy                  658 ms
ok 13        - udf_tg_verify_tables_happy               1275 ms
ok 14        - import_foreign_schema_happy               682 ms
ok 15        - dml_unhappy                               110 ms
ok 16        - data_types_unhappy                        498 ms
ok 17        - case_sensitive_unhappy                     66 ms
ok 18        - prep_dml_unhappy                          124 ms
ok 19        - prep_data_types_unhappy                   597 ms
ok 20        - prep_case_sensitive_unhappy                73 ms
ok 21        - udf_transaction_unhappy                   291 ms
ok 22        - ddl_unhappy                              1089 ms
ok 23        - privilege_unhappy                         214 ms
ok 24        - udf_tg_show_tables_unhappy                 69 ms
ok 25        - udf_tg_show_tables_extra                  563 ms
ok 26        - udf_tg_verify_tables_unhappy               16 ms
ok 27        - udf_tg_verify_tables_extra               1387 ms
ok 28        - import_foreign_schema_unhappy              85 ms
ok 29        - import_foreign_schema_extra               946 ms
ok 30        - subselect                                1941 ms
ok 31        - update                                    431 ms
ok 32        - delete                                     93 ms
ok 33        - with                                      758 ms
ok 34        - sql_features_pg17                         444 ms
ok 35        - user_mapping_happy                        259 ms
ok 36        - user_mapping_unhappy                      360 ms
1..36
# All 36 tests passed.
```