### PR TITLE
ci: bump actions for deprecation of Node 20

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout_Actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           sparse-checkout: .github
 
@@ -40,7 +40,7 @@ jobs:
           make install
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           path: postgresql-${{ matrix.postgresql }}/contrib/tsurugi_fdw
           submodules: recursive


### PR DESCRIPTION
This pull request updates CI workflow dependencies to the latest versions of key GitHub Actions in preparation for the upcoming removal of Node 20 from GitHub Actions runners.
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/